### PR TITLE
Fix Readme typo from Github Org transition

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Avoid forwarding RREPLAY messages to other masters? WARNING: This setting is dan
 
 
 ```
-    scratch-file-path /path
+    db-s3-object /path/to/bucket
 ```
 If you would like KeyDB to dump and load directly to AWS S3 this option specifies the bucket.  Using this option with the traditional RDB options will result in KeyDB backing up twice to both locations.  If both are specified KeyDB will first attempt to load from the local dump file and if that fails load from S3.  This requires the AWS CLI tools to be installed and configured which are used under the hood to transfer the data.
 


### PR DESCRIPTION
Replace mention of scratch-file-path with db-s3-object -- as specified by a [prior version](https://github.com/Snapchat/KeyDB/commit/7bbb50c599d84be7fe768c2807cc85d270b25984#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L66-R102)

I've never used KeyDB, but I had been reading the documentation over the last day or two.  I think this typo cropped up in the Readme during the org transition -- congrats btw -- please confirm it is correct.