### PR TITLE
move operator inefficient handling from gc EpochHolder constructor

### DIFF
--- a/src/gc.h
+++ b/src/gc.h
@@ -16,7 +16,16 @@ class GarbageCollector
     struct EpochHolder
     {
         uint64_t tstamp;
-        std::vector<std::unique_ptr<T>> m_vecObjs;
+        std::unique_ptr<std::vector<std::unique_ptr<T>>> m_spvecObjs;
+
+        EpochHolder() {
+            m_spvecObjs = std::make_unique<std::vector<std::unique_ptr<T>>>();
+        }
+
+        // Support move operators
+        EpochHolder(EpochHolder &&other) = default;
+        EpochHolder &operator=(EpochHolder &&) = default;
+
 
         bool operator<(uint64_t tstamp) const
         {
@@ -108,12 +117,12 @@ public:
         {
             EpochHolder e;
             e.tstamp = m_epochNext+1;
-            e.m_vecObjs.push_back(std::move(sp));
+            e.m_spvecObjs->push_back(std::move(sp));
             m_listepochs.emplace_back(std::move(e));
         }
         else
         {
-            itr->m_vecObjs.push_back(std::move(sp));
+            itr->m_spvecObjs->push_back(std::move(sp));
         }
     }
 


### PR DESCRIPTION
@JohnSully  John,  the current gc.h from the OSS source has an inefficient way of handling the EpochHolder constructor, as we discussed a few weeks ago. When enqueue() was called, it was initialized many times.  On the flame graph, we see that the constructor part of the GC process doubles CPU utilization when GC is enabled.

In the constructor, we agree to optimize the initialization part of the  EpochHolder for vecObjs to avoid running unnecessary calls whenever enqueue() function is called.

Using a master/slave test environment, I verified this change. It indicates that GC CPU consumption used by gc.h constructor has been reduced by half. All other use cases appear to be fine. Please review and merge the changes. Thanks.