### PR TITLE
Use an isb as a pause instruction on arm64 platforms.

### DIFF
--- a/src/fastlock.cpp
+++ b/src/fastlock.cpp
@@ -379,7 +379,11 @@ LNormalLoop:
 #if defined(__i386__) || defined(__amd64__)
             __asm__ __volatile__ ("pause");
 #elif defined(__aarch64__)
-            __asm__ __volatile__ ("yield");
+            /* Use an isb here as we've found it's much closer in duration to
+             * the x86 pause instruction vs. yield which is a nop and thus the
+             * loop count is lower and the interconnect gets a lot more traffic
+             * from loading the ticket above. */
+            __asm__ __volatile__ ("isb");
 #endif
 
             if ((++cloops % loopLimit) == 0)


### PR DESCRIPTION
In other projects spinlock implementations and focused testing we've
found that an isb pauses execution for about the same time as an x86
pause instruction. The yield instruction behaves as a nop and thus
doesn't pause the CPU at all which leads to both more contention on the
lock that is being spun on and also a much lower spin-time vs. x86 for
the same spin loop constants. Given this is userspace code, using a wfe
isn't advisable.