### PR TITLE
Improve CPU utilization when running GC for replication

### DIFF
--- a/src/gc.h
+++ b/src/gc.h
@@ -16,7 +16,17 @@ class GarbageCollector
     struct EpochHolder
     {
         uint64_t tstamp;
-        std::vector<std::unique_ptr<T>> m_vecObjs;
+       	std::unique_ptr<std::vector<std::unique_ptr<T>>> m_spvecObjs;
+
+        EpochHolder() {
+            m_spvecObjs = std::make_unique<std::vector<std::unique_ptr<T>>>();
+        }
+
+        // Support move operators
+        EpochHolder(EpochHolder &&other) = default;
+        EpochHolder &operator=(EpochHolder &&) = default;
+
+
 
         bool operator<(uint64_t tstamp) const
         {
@@ -108,12 +118,12 @@ public:
         {
             EpochHolder e;
             e.tstamp = m_epochNext+1;
-            e.m_vecObjs.push_back(std::move(sp));
+            e.m_spvecObjs->push_back(std::move(sp));
             m_listepochs.emplace_back(std::move(e));
         }
         else
         {
-            itr->m_vecObjs.push_back(std::move(sp));
+            itr->m_spvecObjs->push_back(std::move(sp));
         }
     }
 
@@ -124,3 +134,4 @@ private:
     std::unordered_set<uint64_t> m_setepochOutstanding;
     uint64_t m_epochNext = 0;
 };
+

--- a/src/gc.h
+++ b/src/gc.h
@@ -16,7 +16,7 @@ class GarbageCollector
     struct EpochHolder
     {
         uint64_t tstamp;
-       	std::unique_ptr<std::vector<std::unique_ptr<T>>> m_spvecObjs;
+        std::unique_ptr<std::vector<std::unique_ptr<T>>> m_spvecObjs;
 
         EpochHolder() {
             m_spvecObjs = std::make_unique<std::vector<std::unique_ptr<T>>>();
@@ -134,4 +134,3 @@ private:
     std::unordered_set<uint64_t> m_setepochOutstanding;
     uint64_t m_epochNext = 0;
 };
-


### PR DESCRIPTION
@JohnSully  i verified it against KeyDB open source, the GC takes 10% less CPU consumption during the high pressure tests. You may want to consider of having it. Thanks.