### PR TITLE
Fixes a crash where the server assertion failed when the key exists in DB -- mainly RDB load case

### DIFF
--- a/src/db.cpp
+++ b/src/db.cpp
@@ -2639,7 +2639,11 @@ bool redisDbPersistentData::insert(char *key, robj *o, bool fAssumeNew, dict_ite
         ensure(key);
     dictEntry *de;
     int res = dictAdd(m_pdict, key, o, &de);
-    serverAssert(FImplies(fAssumeNew, res == DICT_OK));
+    if (!FImplies(fAssumeNew, res == DICT_OK)) {
+        serverLog(LL_WARNING,
+            "Assumed new key %s existed in DB.", key);
+    }
+    // serverAssert(FImplies(fAssumeNew, res == DICT_OK));
     if (res == DICT_OK)
     {
 #ifdef CHECKED_BUILD

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -2643,7 +2643,6 @@ bool redisDbPersistentData::insert(char *key, robj *o, bool fAssumeNew, dict_ite
         serverLog(LL_WARNING,
             "Assumed new key %s existed in DB.", key);
     }
-    // serverAssert(FImplies(fAssumeNew, res == DICT_OK));
     if (res == DICT_OK)
     {
 #ifdef CHECKED_BUILD


### PR DESCRIPTION
Under some circumstance when failover happens (especially, a caching use case), data may be reloaded from AOF/RDB file, which could cause the duplication of the keys during the insertion. As per the discussion between @paulmchen and @JohnSully, suggested to change the "Assert" into a Warning message instead of failing the server. 

It might be hard to reproduce the above scenario, and hence to look for an even better solution. As per our investigation, we don't see any potential memory leaks that might be introduced by this fix. However, we would like to see feedbacks on this solution, if there is any. thanks.