### PR TITLE
rocksdb log using up the diskspace on flash

### DIFF
--- a/src/storage/rocksdbfactory.cpp
+++ b/src/storage/rocksdbfactory.cpp
@@ -47,6 +47,7 @@ rocksdb::Options RocksDBStorageFactory::RocksDbOptions()
     options.create_if_missing = true;
     options.create_missing_column_families = true;
     options.info_log_level = rocksdb::ERROR_LEVEL;
+    options.max_total_wal_size = 1 * 1024 * 1024 * 1024;
     return options;
 }
 


### PR DESCRIPTION
This issue is caused by the default max_total_wal_size rocksdb setting used. The default takes 0 as the value for this setting, RocksDB will dynamically choose the WAL size limit to be calculated using the following formula: 

[sum of all write_buffer_size * max_write_buffer_number] * 4].

In the specific test case done by us with a long running flash test, it does a large number of Writes/Deletes operations for 5 days, the number of write buffer is approx 2000, therefore the value (using the  default max_total_wal_size) = 64 * 2000 * 4 = 500 GB. It causes the force flush may not happen until 500 GB diskspace reaches. Since we have a 128 GB SSD disk, the server will fail due to "running out of the disk space on the SSD".

The problem can be identified by going to our flush data path (e.g. /root/data), and run "ls -l *.log |wc -l", we can see a large number of *.log files there and each log is approx. 50 MB in size. If we add all these log files, the total diskspaces used by these logs are about 120GB. That is why it crashed the server with "running out of the diskspaces".

This fix is to use the settings for max_total_wal_size as 1 GB recommended by the RocksDB community, then i have no longer seeing the same issue with running exactly the same long running test cases.

Here is the test case that we ran to verified with the fix:

#!/bin/bash

for ((i=0;i<200;i++));
do
echo "#$i set"
./memtier_benchmark -s 172.31.14.101 -p 6379  -t 10 -c 100 -n 50000 --command='SET __key__ __data__' --data-size-range=1-32 --key-minimum=1 --key-maximum=50000000 --command-key-pattern=P 
echo "$i get"
./memtier_benchmark -s 172.31.14.101 -p 6379  -t 10 -c 100 -n 50000 --command='GET __key__' --key-minimum=1 --key-maximum=50000000 --command-key-pattern=P 
echo "$i del"
./memtier_benchmark -s 172.31.14.101 -p 6379  -t 10 -c 100 -n 50000 --command='DEL __key__' --key-minimum=1 --key-maximum=50000000 --command-key-pattern=P
sleep 120
done