### PR TITLE
Fix ubuntu 22.04 arm build

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,7 @@
 [submodule "deps/rocksdb"]
 	path = deps/rocksdb
-	url = https://github.com/facebook/rocksdb.git
+	url = https://github.com/msotheeswaran/rocksdb.git
+	branch = keydb_6_3_2
 [submodule "deps/depot_tools"]
 	path = deps/depot_tools
 	url = https://chromium.googlesource.com/chromium/tools/depot_tools.git

--- a/src/bitops.cpp
+++ b/src/bitops.cpp
@@ -322,7 +322,7 @@ handle_wrap:
     return 1;
 }
 
-int checkSignedBitfieldOverflow(int64_t value, int64_t incr, uint64_t bits, int owtype, int64_t *limit) {
+int checkSignedBitfieldOverflow(int64_t value, int64_t incr, int bits, int owtype, int64_t *limit) {
     int64_t max = (bits == 64) ? INT64_MAX : (((int64_t)1<<(bits-1))-1);
     int64_t min = (-max)-1;
 


### PR DESCRIPTION
rocksdb fails to compile on ubuntu 22.04 arm, switch to a fork with only the necessary fixes to avoid potential instability