### PR TITLE
remove extra call to handleBlockedClientsTimeout

### DIFF
--- a/src/server.cpp
+++ b/src/server.cpp
@@ -2815,9 +2815,6 @@ void beforeSleep(struct aeEventLoop *eventLoop) {
 
     runAndPropogateToReplicas(processClients);
 
-    /* Handle precise timeouts of blocked clients. */
-    handleBlockedClientsTimeout();
-
     /* Just call a subset of vital functions in case we are re-entering
      * the event loop from processEventsWhileBlocked(). Note that in this
      * case we keep track of the number of events we are processing, since


### PR DESCRIPTION
In redis handleBlockedClientsTimeout is only called after if (ProcessingEventsWhileBlocked), since we return in the if statement this could lead to inconsistent behaviour. There are 2 calls due to bad merging(git blame points to the same commit from redis for both lines).