### PR TITLE
couple AOF fixes

### DIFF
--- a/src/ae.cpp
+++ b/src/ae.cpp
@@ -859,9 +859,9 @@ void aeReleaseForkLock()
     g_forkLock.downgradeWrite();
 }
 
-void aeReleaseForkLockChild()
+void aeForkLockInChild()
 {
-    g_forkLock.downgradeWriteChild();
+    g_forkLock.setNotify(false);
 }
 
 int aeThreadOwnsLock()

--- a/src/ae.cpp
+++ b/src/ae.cpp
@@ -859,6 +859,11 @@ void aeReleaseForkLock()
     g_forkLock.downgradeWrite();
 }
 
+void aeReleaseForkLockChild()
+{
+    g_forkLock.downgradeWriteChild();
+}
+
 int aeThreadOwnsLock()
 {
     return fOwnLockOverride || g_lock.fOwnLock();

--- a/src/ae.h
+++ b/src/ae.h
@@ -171,7 +171,7 @@ int aeTryAcquireLock(int fWeak);
 void aeThreadOffline();
 void aeReleaseLock();
 void aeReleaseForkLock();
-void aeReleaseForkLockChild();
+void aeForkLockInChild();
 int aeThreadOwnsLock();
 void aeSetThreadOwnsLockOverride(int fOverride);
 int aeLockContested(int threshold);

--- a/src/ae.h
+++ b/src/ae.h
@@ -171,6 +171,7 @@ int aeTryAcquireLock(int fWeak);
 void aeThreadOffline();
 void aeReleaseLock();
 void aeReleaseForkLock();
+void aeReleaseForkLockChild();
 int aeThreadOwnsLock();
 void aeSetThreadOwnsLockOverride(int fOverride);
 int aeLockContested(int threshold);

--- a/src/aof.cpp
+++ b/src/aof.cpp
@@ -752,7 +752,7 @@ void feedAppendOnlyFile(struct redisCommand *cmd, int dictid, robj **argv, int a
      * accumulate the differences between the child DB and the current one
      * in a buffer, so that when the child process will do its work we
      * can append the differences to the new append only file. */
-    if (g_pserver->child_type == CHILD_TYPE_AOF)
+    if (hasActiveChildProcess() && g_pserver->child_type == CHILD_TYPE_AOF)
         aofRewriteBufferAppend((unsigned char*)buf,sdslen(buf));
 
     sdsfree(buf);

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -2779,7 +2779,7 @@ standardConfig configs[] = {
     createBoolConfig("appendonly", NULL, MODIFIABLE_CONFIG, g_pserver->aof_enabled, 0, NULL, updateAppendonly),
     createBoolConfig("cluster-allow-reads-when-down", NULL, MODIFIABLE_CONFIG, g_pserver->cluster_allow_reads_when_down, 0, NULL, NULL),
     createBoolConfig("delete-on-evict", NULL, MODIFIABLE_CONFIG, cserver.delete_on_evict, 0, NULL, NULL),
-    createBoolConfig("use-fork", NULL, IMMUTABLE_CONFIG, cserver.fForkBgSave, 1, NULL, NULL),
+    createBoolConfig("use-fork", NULL, IMMUTABLE_CONFIG, cserver.fForkBgSave, 0, NULL, NULL),
     createBoolConfig("io-threads-do-reads", NULL, IMMUTABLE_CONFIG, fDummy, 0, NULL, NULL),
     createBoolConfig("time-thread-priority", NULL, IMMUTABLE_CONFIG, cserver.time_thread_priority, 0, NULL, NULL),
     createBoolConfig("prefetch-enabled", NULL, MODIFIABLE_CONFIG, g_pserver->prefetch_enabled, 1, NULL, NULL),

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -2779,7 +2779,7 @@ standardConfig configs[] = {
     createBoolConfig("appendonly", NULL, MODIFIABLE_CONFIG, g_pserver->aof_enabled, 0, NULL, updateAppendonly),
     createBoolConfig("cluster-allow-reads-when-down", NULL, MODIFIABLE_CONFIG, g_pserver->cluster_allow_reads_when_down, 0, NULL, NULL),
     createBoolConfig("delete-on-evict", NULL, MODIFIABLE_CONFIG, cserver.delete_on_evict, 0, NULL, NULL),
-    createBoolConfig("use-fork", NULL, IMMUTABLE_CONFIG, cserver.fForkBgSave, 0, NULL, NULL),
+    createBoolConfig("use-fork", NULL, IMMUTABLE_CONFIG, cserver.fForkBgSave, 1, NULL, NULL),
     createBoolConfig("io-threads-do-reads", NULL, IMMUTABLE_CONFIG, fDummy, 0, NULL, NULL),
     createBoolConfig("time-thread-priority", NULL, IMMUTABLE_CONFIG, cserver.time_thread_priority, 0, NULL, NULL),
     createBoolConfig("prefetch-enabled", NULL, MODIFIABLE_CONFIG, g_pserver->prefetch_enabled, 1, NULL, NULL),

--- a/src/rdb.cpp
+++ b/src/rdb.cpp
@@ -3694,7 +3694,7 @@ void killRDBChild(bool fSynchronous) {
     serverAssert(GlobalLocksAcquired());
 
     if (cserver.fForkBgSave) {
-        kill(g_pserver->rdb_child_pid,SIGUSR1);
+        kill(g_pserver->child_pid,SIGUSR1);
     } else { 
         g_pserver->rdbThreadVars.fRdbThreadCancel = true;
         if (g_pserver->rdb_child_type == RDB_CHILD_TYPE_SOCKET) {

--- a/src/readwritelock.h
+++ b/src/readwritelock.h
@@ -77,8 +77,22 @@ public:
         m_cv.notify_all();
     }
 
+    void releaseWriteChild(bool exclusive = true) {
+        std::unique_lock<fastlock> rm(m_readLock);
+        serverAssert(m_writeCount > 0);
+        if (exclusive)
+            m_writeLock.unlock();
+        m_writeCount--;
+        m_writeWaiting = false;
+    }
+
     void downgradeWrite(bool exclusive = true) {
         releaseWrite(exclusive);
+        acquireRead();
+    }
+
+    void downgradeWriteChild(bool exclusive = true) {
+        releaseWriteChild(exclusive);
         acquireRead();
     }
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -6888,7 +6888,6 @@ int redisFork(int purpose) {
     latencyAddSampleIfNeeded("fork-lock",(ustime()-startWriteLock)/1000);
     if ((childpid = fork()) == 0) {
         /* Child */
-        aeReleaseForkLock();
         g_pserver->in_fork_child = purpose;
         setOOMScoreAdj(CONFIG_OOM_BGCHILD);
         setupChildSignalHandlers();

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -6888,7 +6888,8 @@ int redisFork(int purpose) {
     latencyAddSampleIfNeeded("fork-lock",(ustime()-startWriteLock)/1000);
     if ((childpid = fork()) == 0) {
         /* Child */
-        aeReleaseForkLockChild();
+        aeForkLockInChild();
+        aeReleaseForkLock();
         g_pserver->in_fork_child = purpose;
         setOOMScoreAdj(CONFIG_OOM_BGCHILD);
         setupChildSignalHandlers();

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -6888,6 +6888,7 @@ int redisFork(int purpose) {
     latencyAddSampleIfNeeded("fork-lock",(ustime()-startWriteLock)/1000);
     if ((childpid = fork()) == 0) {
         /* Child */
+        aeReleaseForkLockChild();
         g_pserver->in_fork_child = purpose;
         setOOMScoreAdj(CONFIG_OOM_BGCHILD);
         setupChildSignalHandlers();


### PR DESCRIPTION
technically possible for child_type == CHILD_TYPE_AOF without active child in feedAppendOnlyFile so check to make sure there is an actual child when writing to buffer.

aof rewrite child can hang if another thread was calling cv_wait, just don't cv_notify in child, don't care about other threads in child process anyways (fixes #468)


0  futex_wait (private=0, expected=3, futex_word=0x564005575430 <g_forkLock+272>) at ../sysdeps/nptl/futex-internal.h:146
1  futex_wait_simple (private=0, expected=3, futex_word=0x564005575430 <g_forkLock+272>) at ../sysdeps/nptl/futex-internal.h:177
2  __condvar_quiesce_and_switch_g1 (private=0, g1index=<synthetic pointer>, wseq=<optimized out>, cond=0x564005575420 <g_forkLock+256>) at ./nptl/pthread_cond_common.c:276
3  ___pthread_cond_broadcast (cond=0x564005575420 <g_forkLock+256>) at ./nptl/pthread_cond_broadcast.c:72
4  0x00005640053190ca in std::_V2::condition_variable_any::notify_all (this=<optimized out>) at /usr/include/c++/11/condition_variable:300
5  readWriteLock::releaseWrite (exclusive=true, this=<optimized out>) at /home/msotheeswaran/KeyDB/src/readwritelock.h:77
6  readWriteLock::downgradeWrite (exclusive=true, this=<optimized out>) at /home/msotheeswaran/KeyDB/src/readwritelock.h:81
7  aeReleaseForkLock () at /home/msotheeswaran/KeyDB/src/ae.cpp:859
8  redisFork (purpose=2) at /home/msotheeswaran/KeyDB/src/server.cpp:6891
9  0x00005640053a06b6 in rewriteAppendOnlyFileBackground () at /home/msotheeswaran/KeyDB/src/aof.cpp:1892