### PR TITLE
Close child info pipes when RDB save thread is done.

### DIFF
--- a/src/server.cpp
+++ b/src/server.cpp
@@ -2219,6 +2219,7 @@ void checkChildrenDone(void) {
             g_pserver->rdbThreadVars.fRdbThreadCancel = false;
             g_pserver->rdbThreadVars.fDone = false;
             if (exitcode == 0) receiveChildInfo();
+            closeChildInfoPipe();
         }
     }
     else if ((pid = waitpid(-1, &statloc, WNOHANG)) != 0) {


### PR DESCRIPTION
Make sure to close child info pipes when background save thread is done. This avoids leaking two pipes per every background RDB save. Hopefully this fixes #537. 