### PR TITLE
Add key eviction number for storage

### DIFF
--- a/src/evict.cpp
+++ b/src/evict.cpp
@@ -771,6 +771,7 @@ int performEvictions(bool fPreSnapshot) {
                 if (db->removeCachedValue(bestkey, &deT)) {
                     mem_freed += splazy->addEntry(db->dictUnsafeKeyOnly(), deT);
                     ckeysFailed = 0;
+		    g_pserver->stat_evictedkeys++;
                 }
                 else {
                     delta = 0;


### PR DESCRIPTION
Current, if we set  storage-provider in config file, and even key eviction process happen, 
the key eviction number is still 0
This PR fix this issue and eviction-key number update during the key evction process as below:

# Stats
total_connections_received:201
total_commands_processed:3105600
instantaneous_ops_per_sec:60758
total_net_input_bytes:930820885
total_net_output_bytes:15565658
instantaneous_input_kbps:17779.66
instantaneous_output_kbps:296.75
rejected_connections:0
sync_full:0
sync_partial_ok:0
sync_partial_err:0
expired_keys:0
expired_stale_perc:0.00
expired_time_cap_reached_count:0
expire_cycle_cpu_milliseconds:0
**evicted_keys:976558**
keyspace_hits:0
keyspace_misses:0
pubsub_channels:0
pubsub_patterns:0
latest_fork_usec:0
total_forks:0
migrate_cached_sockets:0
slave_expires_tracked_keys:0
active_defrag_hits:0
active_defrag_misses:0
active_defrag_key_hits:0
active_defrag_key_misses:0
tracking_total_keys:0
tracking_total_items:0
tracking_total_prefixes:0
unexpected_error_replies:0
total_error_replies:0
dump_payload_sanitizations:0
total_reads_processed:3105676
total_writes_processed:3105584
instantaneous_lock_contention:2
avg_lock_contention:1.359375
**storage_provider_read_hits:53
storage_provider_read_misses:908426**