### PR TITLE
restore fork impl of save to replica sockets

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -2806,7 +2806,7 @@ standardConfig configs[] = {
     createBoolConfig("appendonly", NULL, MODIFIABLE_CONFIG, g_pserver->aof_enabled, 0, NULL, updateAppendonly),
     createBoolConfig("cluster-allow-reads-when-down", NULL, MODIFIABLE_CONFIG, g_pserver->cluster_allow_reads_when_down, 0, NULL, NULL),
     createBoolConfig("delete-on-evict", NULL, MODIFIABLE_CONFIG, cserver.delete_on_evict, 0, NULL, NULL),
-    createBoolConfig("use-fork", NULL, IMMUTABLE_CONFIG, cserver.fForkBgSave, 0, NULL, NULL),
+    createBoolConfig("use-fork", NULL, IMMUTABLE_CONFIG, cserver.fForkBgSave, 1, NULL, NULL),
     createBoolConfig("io-threads-do-reads", NULL, IMMUTABLE_CONFIG, fDummy, 0, NULL, NULL),
     createBoolConfig("time-thread-priority", NULL, IMMUTABLE_CONFIG, cserver.time_thread_priority, 0, NULL, NULL),
     createBoolConfig("prefetch-enabled", NULL, MODIFIABLE_CONFIG, g_pserver->prefetch_enabled, 1, NULL, NULL),

--- a/src/evict.cpp
+++ b/src/evict.cpp
@@ -378,6 +378,8 @@ size_t freeMemoryGetNotCountedMemory(void) {
         }
     }
 
+    /* also don't count the replication backlog memory
+     * that's where the replication clients get their memory from */
     overhead += g_pserver->repl_backlog_size;
 
     if (g_pserver->aof_state != AOF_OFF) {

--- a/src/evict.cpp
+++ b/src/evict.cpp
@@ -378,10 +378,6 @@ size_t freeMemoryGetNotCountedMemory(void) {
         }
     }
 
-    /* also don't count the replication backlog memory
-     * that's where the replication clients get their memory from */
-    overhead += g_pserver->repl_backlog_size;
-
     if (g_pserver->aof_state != AOF_OFF) {
         overhead += sdsalloc(g_pserver->aof_buf)+aofRewriteBufferSize();
     }

--- a/src/evict.cpp
+++ b/src/evict.cpp
@@ -378,6 +378,8 @@ size_t freeMemoryGetNotCountedMemory(void) {
         }
     }
 
+    overhead += g_pserver->repl_backlog_size;
+
     if (g_pserver->aof_state != AOF_OFF) {
         overhead += sdsalloc(g_pserver->aof_buf)+aofRewriteBufferSize();
     }

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -5172,7 +5172,7 @@ int prepareForShutdown(int flags) {
          * to unlink file actully) in background thread.
          * The temp rdb file fd may won't be closed when redis exits quickly,
          * but OS will close this fd when process exits. */
-        rdbRemoveTempFile(g_pserver->child_pid, 0);
+        rdbRemoveTempFile(g_pserver->rdbThreadVars.tmpfileNum, 0);
     }
 
     /* Kill module child if there is one. */


### PR DESCRIPTION
causes crash when use-fork is true as it creates a threaded bgsave instead of a fork as expected. Fixes #567.

change default to fork bgsave instead of forkless. 

Also remove incorrect inclusion of repl_backlog_size from acceptable overhead for maxmemory. Fixes #601.