### PR TITLE
remove noexcept for alpine

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -349,7 +349,7 @@ endif
 # Alpine OS doesn't have support for the execinfo backtrace library we use for debug, so we provide an alternate implementation using libwunwind.
 OS := $(shell cat /etc/os-release | grep ID= | head -n 1 | cut -d'=' -f2)
 ifeq ($(OS),alpine)
-    FINAL_CXXFLAGS+=-DUNW_LOCAL_ONLY
+    FINAL_CXXFLAGS+=-DUNW_LOCAL_ONLY -DALPINE
     FINAL_LIBS += -lunwind
 endif
 

--- a/src/server.h
+++ b/src/server.h
@@ -3894,13 +3894,29 @@ void incrementMvccTstamp();
 
 #if __GNUC__ >= 7 && !defined(NO_DEPRECATE_FREE)
  [[deprecated]]
+#ifdef ALPINE
+void *calloc(size_t count, size_t size);
+#else
 void *calloc(size_t count, size_t size) noexcept;
+#endif
  [[deprecated]]
+#ifdef ALPINE
+void free(void *ptr);
+#else
 void free(void *ptr) noexcept;
+#endif
  [[deprecated]]
+#ifdef ALPINE
+void *malloc(size_t size);
+#else
 void *malloc(size_t size) noexcept;
+#endif
  [[deprecated]]
+#ifdef ALPINE
+void *realloc(void *ptr, size_t size);
+#else
 void *realloc(void *ptr, size_t size) noexcept;
+#endif
 #endif
 
 /* Debugging stuff */


### PR DESCRIPTION
Alpine doesn't compile with noexcept malloc functions.