### PR TITLE
Flash expire

### DIFF
--- a/src/IStorage.h
+++ b/src/IStorage.h
@@ -31,6 +31,7 @@ public:
     virtual void retrieve(const char *key, size_t cchKey, callbackSingle fn) const = 0;
     virtual size_t clear() = 0;
     virtual bool enumerate(callback fn) const = 0;
+    virtual size_t stateful_enumerate(callback fn) = 0;
     virtual size_t count() const = 0;
 
     virtual void bulkInsert(char **rgkeys, size_t *rgcbkeys, char **rgvals, size_t *rgcbvals, size_t celem) {

--- a/src/StorageCache.h
+++ b/src/StorageCache.h
@@ -49,6 +49,7 @@ public:
     void expand(uint64_t slots);
 
     bool enumerate(IStorage::callback fn) const { return m_spstorage->enumerate(fn); }
+    size_t stateful_enumerate(IStorage::callback fn) { return m_spstorage->stateful_enumerate(fn); }
 
     void beginWriteBatch();
     void endWriteBatch() { m_spstorage->endWriteBatch(); }

--- a/src/evict.cpp
+++ b/src/evict.cpp
@@ -771,7 +771,7 @@ int performEvictions(bool fPreSnapshot) {
                 if (db->removeCachedValue(bestkey, &deT)) {
                     mem_freed += splazy->addEntry(db->dictUnsafeKeyOnly(), deT);
                     ckeysFailed = 0;
-		    g_pserver->stat_evictedkeys++;
+                    g_pserver->stat_evictedkeys++;
                 }
                 else {
                     delta = 0;

--- a/src/server.h
+++ b/src/server.h
@@ -1209,6 +1209,7 @@ public:
     bool FSnapshot() const { return m_spdbSnapshotHOLDER != nullptr; }
 
     std::unique_ptr<const StorageCache> CloneStorageCache() { return std::unique_ptr<const StorageCache>(m_spstorage->clone()); }
+    std::shared_ptr<StorageCache> getStorageCache() { return m_spstorage; }
     void bulkDirectStorageInsert(char **rgKeys, size_t *rgcbKeys, char **rgVals, size_t *rgcbVals, size_t celem);
 
     dict_iter find_cached_threadsafe(const char *key) const;
@@ -1371,6 +1372,7 @@ struct redisDb : public redisDbPersistentDataSnapshot
     using redisDbPersistentData::FTrackingChanges;
     using redisDbPersistentData::CloneStorageCache;
     using redisDbPersistentData::bulkDirectStorageInsert;
+    using redisDbPersistentData::getStorageCache;
 
 public:
     const redisDbPersistentDataSnapshot *createSnapshot(uint64_t mvccCheckpoint, bool fOptional) {

--- a/src/storage/rocksdb.cpp
+++ b/src/storage/rocksdb.cpp
@@ -170,8 +170,10 @@ bool RocksDBStorageProvider::enumerate(callback fn) const
 
 size_t RocksDBStorageProvider::stateful_enumerate(callback fn)
 {
-    if (m_iter == nullptr || !m_iter->Valid())
+    if (m_iter == nullptr || !m_iter->Valid()) {
         m_iter = std::unique_ptr<rocksdb::Iterator>(m_spdb->NewIterator(ReadOptions(), m_spcolfamily.get()));
+        m_iter->SeekToFirst();
+    }
     size_t count = 0;
     while (m_iter->Valid()) {
         if (FInternalKey(m_iter->key().data(), m_iter->key().size()))

--- a/src/storage/rocksdb.h
+++ b/src/storage/rocksdb.h
@@ -22,6 +22,7 @@ class RocksDBStorageProvider : public IStorage
     rocksdb::ReadOptions m_readOptionsTemplate;
     size_t m_count = 0;
     mutable fastlock m_lock {"RocksDBStorageProvider"};
+    std::unique_ptr<rocksdb::Iterator> m_iter;
 
 public:
     RocksDBStorageProvider(RocksDBStorageFactory *pfactory, std::shared_ptr<rocksdb::DB> &spdb, std::shared_ptr<rocksdb::ColumnFamilyHandle> &spcolfam, const rocksdb::Snapshot *psnapshot, size_t count);
@@ -32,6 +33,7 @@ public:
     virtual void retrieve(const char *key, size_t cchKey, callbackSingle fn) const override;
     virtual size_t clear() override;
     virtual bool enumerate(callback fn) const override;
+    virtual size_t stateful_enumerate(callback fn) override;
 
     virtual const IStorage *clone() const override;
 

--- a/src/storage/teststorageprovider.cpp
+++ b/src/storage/teststorageprovider.cpp
@@ -73,6 +73,26 @@ bool TestStorageProvider::enumerate(callback fn) const
     }
     return fAll;
 }
+
+size_t TestStorageProvider::stateful_enumerate(callback fn)
+{
+    size_t count = 0;
+    if (m_iter == m_map.end())
+        m_iter = m_map.begin();
+
+    while (m_iter != m_map.end())
+    {
+        if (fn(m_iter->first.data(), m_iter->first.size(), m_iter->second.data(), m_iter->second.size()))
+        {
+            m_iter++;
+            count++;
+        } else
+        {
+            break;
+        }
+    }
+    return count;
+}
     
 size_t TestStorageProvider::count() const
 {

--- a/src/storage/teststorageprovider.h
+++ b/src/storage/teststorageprovider.h
@@ -14,6 +14,7 @@ class TestStorageFactory : public IStorageFactory
 class TestStorageProvider final : public IStorage
 {
     std::unordered_map<std::string, std::string> m_map;
+    std::unordered_map<std::string, std::string>::iterator m_iter = m_map.end();
 
 public:
     TestStorageProvider();
@@ -24,6 +25,7 @@ public:
     virtual void retrieve(const char *key, size_t cchKey, callbackSingle fn) const override;
     virtual size_t clear() override;
     virtual bool enumerate(callback fn) const override;
+    virtual size_t stateful_enumerate(callback fn) override;
     virtual size_t count() const override;
 
     virtual void flush() override;

--- a/tests/unit/flash.tcl
+++ b/tests/unit/flash.tcl
@@ -122,18 +122,20 @@ if {$::flash_enabled} {
 
         test { Keys in storage are expired } {
             r flushdb
-            r psetex key1 500 a
-            r psetex key2 500 a
-            r psetex key3 500 a
+            r psetex key1 1000 a
+            r psetex key2 1000 a
+            r psetex key3 1000 a
             r flushall cache
-            set size1 [r dbsize]
             # Redis expires random keys ten times every second so we are
             # fairly sure that all the three keys should be evicted after
             # one second.
             after 1000
-            set size2 [r dbsize]
-            list $size1 $size2
-        } {3 0}
+            wait_for_condition 100 50 {
+                [r dbsize] == 0
+            } else {
+                fail "keys in ssd only not expired"
+            }
+        }
 
         r flushall
         # If a weak storage memory model is set, wait for any pending snapshot writes to finish

--- a/tests/unit/flash.tcl
+++ b/tests/unit/flash.tcl
@@ -122,15 +122,13 @@ if {$::flash_enabled} {
 
         test { Keys in storage are expired } {
             r flushdb
-            r psetex key1 1000 a
-            r psetex key2 1000 a
-            r psetex key3 1000 a
+            r psetex key1 10000 a
+            r psetex key2 10000 a
+            r psetex key3 10000 a
             r flushall cache
-            # Redis expires random keys ten times every second so we are
-            # fairly sure that all the three keys should be evicted after
-            # one second.
+
             after 1000
-            wait_for_condition 100 50 {
+            wait_for_condition 1000 50 {
                 [r dbsize] == 0
             } else {
                 fail "keys in ssd only not expired"

--- a/tests/unit/flash.tcl
+++ b/tests/unit/flash.tcl
@@ -120,6 +120,21 @@ if {$::flash_enabled} {
             assert_equal {2} [r scard set1]
         }
 
+        test { Keys in storage are expired } {
+            r flushdb
+            r psetex key1 500 a
+            r psetex key2 500 a
+            r psetex key3 500 a
+            r flushall cache
+            set size1 [r dbsize]
+            # Redis expires random keys ten times every second so we are
+            # fairly sure that all the three keys should be evicted after
+            # one second.
+            after 1000
+            set size2 [r dbsize]
+            list $size1 $size2
+        } {3 0}
+
         r flushall
         # If a weak storage memory model is set, wait for any pending snapshot writes to finish
         after 500 


### PR DESCRIPTION
Adds a stateful enumerate method to IStorage interface, this method will iterate over every key in the storage provider and stop when the provided function returns false, subsequent calls to this method will continue iteration where the last call left off, rather than from the beginning.

Added an extra step in active expire to use stateful enumerate to check expiry of all keys in storage provider once there are no more keys to check in memory.