### PR TITLE
Flash slot to key

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,0 +1,53 @@
+# Doc: https://wiki.sc-corp.net/pages/viewpage.action?pageId=121500284
+version: 1
+machamp:
+  keydb-build:
+    # Optional - build counter is linked to the build def
+    tag_template: 0.0.%build.counter%
+    # Optional - value in seconds before a build is terminated, default is 3600 seconds
+    timeout: 3600
+    # Optional - update ghe or not, default to true
+    update_ghe: true
+    code_coverage: false
+    # Required
+    steps:
+      make-build:
+        type: cmd
+        # https://github.sc-corp.net/Snapchat/img/tree/master/keydb/ubuntu-20-04
+        builder_image: us.gcr.io/snapchat-build-artifacts/prod/snapchat/img/keydb/keydb-ubuntu-20-04@sha256:cf869a3f5d1de1e1d976bb906689c37b7031938eb68661b844a38c532f27248c
+        command: ./machamp_scripts/build.sh
+      tls-test:
+        type: cmd
+        parent: make-build
+        # https://github.sc-corp.net/Snapchat/img/tree/master/keydb/ubuntu-20-04
+        builder_image: us.gcr.io/snapchat-build-artifacts/prod/snapchat/img/keydb/keydb-ubuntu-20-04@sha256:cf869a3f5d1de1e1d976bb906689c37b7031938eb68661b844a38c532f27248c
+        command: ./runtest --clients 4 --verbose 
+      cluster-test:
+        type: cmd
+        parent: make-build
+        # https://github.sc-corp.net/Snapchat/img/tree/master/keydb/ubuntu-20-04
+        builder_image: us.gcr.io/snapchat-build-artifacts/prod/snapchat/img/keydb/keydb-ubuntu-20-04@sha256:cf869a3f5d1de1e1d976bb906689c37b7031938eb68661b844a38c532f27248c
+        command: ./runtest-cluster 
+      sentinel-test:
+        type: cmd
+        parent: make-build
+        # https://github.sc-corp.net/Snapchat/img/tree/master/keydb/ubuntu-20-04
+        builder_image: us.gcr.io/snapchat-build-artifacts/prod/snapchat/img/keydb/keydb-ubuntu-20-04@sha256:cf869a3f5d1de1e1d976bb906689c37b7031938eb68661b844a38c532f27248c
+        command: ./runtest-sentinel
+      module-test:
+        type: cmd
+        parent: make-build
+        # https://github.sc-corp.net/Snapchat/img/tree/master/keydb/ubuntu-20-04
+        builder_image: us.gcr.io/snapchat-build-artifacts/prod/snapchat/img/keydb/keydb-ubuntu-20-04@sha256:cf869a3f5d1de1e1d976bb906689c37b7031938eb68661b844a38c532f27248c
+        command: ./runtest-moduleapi
+      rotation-test:
+        type: cmd
+        parent: make-build
+        # https://github.sc-corp.net/Snapchat/img/tree/master/keydb/ubuntu-20-04
+        builder_image: us.gcr.io/snapchat-build-artifacts/prod/snapchat/img/keydb/keydb-ubuntu-20-04@sha256:cf869a3f5d1de1e1d976bb906689c37b7031938eb68661b844a38c532f27248c
+        command: ./runtest-rotation
+      keyproxy-test:
+        type: cmd
+        parent: make-build
+        command: ./runtest-keyproxy --tls
+        builder_image: us.gcr.io/snapchat-build-artifacts/prod/snapchat/img/keydb/keydb-ubuntu-20-04@sha256:cf869a3f5d1de1e1d976bb906689c37b7031938eb68661b844a38c532f27248c

--- a/ci.yaml
+++ b/ci.yaml
@@ -9,7 +9,7 @@ on:
         build_name: keydb-build
         arch_types: ["amd64", "arm64"]
   push:
-    - branches: [keydbpro]
+    - branches: [main]
       workflows:
         - workflow_type: backend_workflow
           build_name: keydb-build

--- a/ci.yaml
+++ b/ci.yaml
@@ -1,0 +1,16 @@
+# Doc: https://wiki.sc-corp.net/display/TOOL/ci.yaml+User+Guide
+version: 1
+on:
+  pull_request:
+    - workflows:
+      # All builds that use machamp should use the defined `backend_workflow`
+      - workflow_type: backend_workflow
+        # references a build defined in build.yaml
+        build_name: keydb-build
+        arch_types: ["amd64", "arm64"]
+  push:
+    - branches: [keydbpro]
+      workflows:
+        - workflow_type: backend_workflow
+          build_name: keydb-build
+          arch_types: ["amd64", "arm64"]

--- a/machamp_scripts/build.sh
+++ b/machamp_scripts/build.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# make the build
+git submodule init && git submodule update
+make BUILD_TLS=yes -j$(nproc) KEYDB_CFLAGS='-Werror' KEYDB_CXXFLAGS='-Werror'
+
+# gen-cert
+./utils/gen-test-certs.sh

--- a/src/IStorage.h
+++ b/src/IStorage.h
@@ -31,6 +31,7 @@ public:
     virtual void retrieve(const char *key, size_t cchKey, callbackSingle fn) const = 0;
     virtual size_t clear() = 0;
     virtual bool enumerate(callback fn) const = 0;
+    virtual bool enumerate_hashslot(callback fn, int hashslot) const = 0;
     virtual size_t count() const = 0;
 
     virtual void bulkInsert(char **rgkeys, size_t *rgcbkeys, char **rgvals, size_t *rgcbvals, size_t celem) {

--- a/src/IStorage.h
+++ b/src/IStorage.h
@@ -31,7 +31,7 @@ public:
     virtual void retrieve(const char *key, size_t cchKey, callbackSingle fn) const = 0;
     virtual size_t clear() = 0;
     virtual bool enumerate(callback fn) const = 0;
-    virtual bool enumerate_hashslot(callback fn, int hashslot) const = 0;
+    virtual bool enumerate_hashslot(callback fn, unsigned int hashslot) const = 0;
     virtual size_t count() const = 0;
 
     virtual void bulkInsert(char **rgkeys, size_t *rgcbkeys, char **rgvals, size_t *rgcbvals, size_t celem) {

--- a/src/StorageCache.h
+++ b/src/StorageCache.h
@@ -49,7 +49,7 @@ public:
     void expand(uint64_t slots);
 
     bool enumerate(IStorage::callback fn) const { return m_spstorage->enumerate(fn); }
-    bool enumerate_hashslot(IStorage::callback fn, int hashslot) const { return m_spstorage->enumerate_hashslot(fn, hashslot); }
+    bool enumerate_hashslot(IStorage::callback fn, unsigned int hashslot) const { return m_spstorage->enumerate_hashslot(fn, hashslot); }
 
     void beginWriteBatch();
     void endWriteBatch() { m_spstorage->endWriteBatch(); }

--- a/src/StorageCache.h
+++ b/src/StorageCache.h
@@ -49,6 +49,7 @@ public:
     void expand(uint64_t slots);
 
     bool enumerate(IStorage::callback fn) const { return m_spstorage->enumerate(fn); }
+    bool enumerate_hashslot(IStorage::callback fn, int hashslot) const { return m_spstorage->enumerate_hashslot(fn, hashslot); }
 
     void beginWriteBatch();
     void endWriteBatch() { m_spstorage->endWriteBatch(); }

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -2489,10 +2489,10 @@ void slotToKeyUpdateKey(sds key, int add) {
 void slotToKeyUpdateKeyCore(const char *key, size_t keylen, int add) {
     serverAssert(GlobalLocksAcquired());
 
+    unsigned int hashslot = keyHashSlot(key,keylen);
     g_pserver->cluster->slots_keys_count[hashslot] += add ? 1 : -1;
 
     if (g_pserver->m_pstorageFactory == nullptr) {
-        unsigned int hashslot = keyHashSlot(key,keylen);
         unsigned char buf[64];
         unsigned char *indexed = buf;
 

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -2553,6 +2553,7 @@ unsigned int getKeysInSlot(unsigned int hashslot, robj **keys, unsigned int coun
             keys[j++] = createStringObject(key, cchKey);
             return --count;
         }, hashslot);
+        return j;
     } else {
         raxIterator iter;
         int j = 0;

--- a/src/server.h
+++ b/src/server.h
@@ -1209,6 +1209,7 @@ public:
     bool FSnapshot() const { return m_spdbSnapshotHOLDER != nullptr; }
 
     std::unique_ptr<const StorageCache> CloneStorageCache() { return std::unique_ptr<const StorageCache>(m_spstorage->clone()); }
+    std::shared_ptr<StorageCache> getStorageCache() { return m_spstorage; }
     void bulkDirectStorageInsert(char **rgKeys, size_t *rgcbKeys, char **rgVals, size_t *rgcbVals, size_t celem);
 
     dict_iter find_cached_threadsafe(const char *key) const;
@@ -1370,6 +1371,7 @@ struct redisDb : public redisDbPersistentDataSnapshot
     using redisDbPersistentData::FRehashing;
     using redisDbPersistentData::FTrackingChanges;
     using redisDbPersistentData::CloneStorageCache;
+    using redisDbPersistentData::getStorageCache();
     using redisDbPersistentData::bulkDirectStorageInsert;
 
 public:

--- a/src/server.h
+++ b/src/server.h
@@ -1371,7 +1371,7 @@ struct redisDb : public redisDbPersistentDataSnapshot
     using redisDbPersistentData::FRehashing;
     using redisDbPersistentData::FTrackingChanges;
     using redisDbPersistentData::CloneStorageCache;
-    using redisDbPersistentData::getStorageCache();
+    using redisDbPersistentData::getStorageCache;
     using redisDbPersistentData::bulkDirectStorageInsert;
 
 public:

--- a/src/storage/rocksdb.cpp
+++ b/src/storage/rocksdb.cpp
@@ -206,6 +206,7 @@ bool RocksDBStorageProvider::enumerate_hashslot(callback fn, int hashslot) const
     {
         printf("WARNING: rocksdb hashslot count mismatch");
     }
+    assert(!full_iter || count == g_pserver->cluster->slots_keys_count[hashslot]);
     assert(it->status().ok()); // Check for any errors found during the scan
     return full_iter;
 }

--- a/src/storage/rocksdb.cpp
+++ b/src/storage/rocksdb.cpp
@@ -22,7 +22,7 @@ bool FInternalKey(const char *key, size_t cch)
     return false;
 }
 
-std::string getPrefix(int hashslot)
+std::string getPrefix(unsigned int hashslot)
 {
     char *hash_char = (char *)&hashslot;
     return std::string(hash_char + (sizeof(unsigned int) - 2), 2);
@@ -186,7 +186,7 @@ bool RocksDBStorageProvider::enumerate(callback fn) const
     return !it->Valid();
 }
 
-bool RocksDBStorageProvider::enumerate_hashslot(callback fn, int hashslot) const
+bool RocksDBStorageProvider::enumerate_hashslot(callback fn, unsigned int hashslot) const
 {
     std::string prefix = getPrefix(hashslot);
     std::unique_ptr<rocksdb::Iterator> it = std::unique_ptr<rocksdb::Iterator>(m_spdb->NewIterator(ReadOptions(), m_spcolfamily.get()));

--- a/src/storage/rocksdb.cpp
+++ b/src/storage/rocksdb.cpp
@@ -191,10 +191,10 @@ bool RocksDBStorageProvider::enumerate_hashslot(callback fn, int hashslot) const
     std::string prefix = getPrefix(hashslot);
     std::unique_ptr<rocksdb::Iterator> it = std::unique_ptr<rocksdb::Iterator>(m_spdb->NewIterator(ReadOptions(), m_spcolfamily.get()));
     size_t count = 0;
-    for (it->Seek(prefix.cstr()); it->Valid(); it->Next()) {
+    for (it->Seek(prefix.c_str()); it->Valid(); it->Next()) {
         if (FInternalKey(it->key().data(), it->key().size()))
             continue;
-        if (strncmp(it->key().data(),prefix.cstr(),2) != 0)
+        if (strncmp(it->key().data(),prefix.c_str(),2) != 0)
             break;
         ++count;
         bool fContinue = fn(it->key().data()+2, it->key().size()-2, it->value().data(), it->value().size());

--- a/src/storage/rocksdb.cpp
+++ b/src/storage/rocksdb.cpp
@@ -165,7 +165,7 @@ bool RocksDBStorageProvider::enumerate(callback fn) const
     std::unique_ptr<rocksdb::Iterator> it = std::unique_ptr<rocksdb::Iterator>(m_spdb->NewIterator(ReadOptions(), m_spcolfamily.get()));
     size_t count = 0;
     for (it->SeekToFirst(); it->Valid(); it->Next()) {
-        if (FInternalKey(it->key().data()+2, it->key().size()-2))
+        if (FInternalKey(it->key().data(), it->key().size()))
             continue;
         ++count;
         bool fContinue = fn(it->key().data()+2, it->key().size()-2, it->value().data(), it->value().size());

--- a/src/storage/rocksdb.cpp
+++ b/src/storage/rocksdb.cpp
@@ -12,13 +12,6 @@ static const char keyprefix[] = INTERNAL_KEY_PREFIX;
 rocksdb::Options DefaultRocksDBOptions();
 extern "C" pid_t gettid();
 
-std::string prefixKey(const char *key, size_t cchKey)
-{
-    unsigned int hash = keyHashSlot(key, cchKey);
-    char *hash_char = (char *)&hash;
-    return std::string(hash_char + (sizeof(unsigned int) - 2), 2) + std::string(key, cchKey);
-}
-
 bool FInternalKey(const char *key, size_t cch)
 {
     if (cch >= sizeof(INTERNAL_KEY_PREFIX))
@@ -27,6 +20,13 @@ bool FInternalKey(const char *key, size_t cch)
             return true;
     }
     return false;
+}
+
+std::string prefixKey(const char *key, size_t cchKey)
+{
+    unsigned int hash = keyHashSlot(key, cchKey);
+    char *hash_char = (char *)&hash;
+    return FInternalKey(key, cchKey) ? std::string(key, cchKey) : std::string(hash_char + (sizeof(unsigned int) - 2), 2) + std::string(key, cchKey);
 }
 
 RocksDBStorageProvider::RocksDBStorageProvider(RocksDBStorageFactory *pfactory, std::shared_ptr<rocksdb::DB> &spdb, std::shared_ptr<rocksdb::ColumnFamilyHandle> &spcolfam, const rocksdb::Snapshot *psnapshot, size_t count)

--- a/src/storage/rocksdb.cpp
+++ b/src/storage/rocksdb.cpp
@@ -201,7 +201,7 @@ bool RocksDBStorageProvider::enumerate_hashslot(callback fn, int hashslot) const
         if (!fContinue)
             break;
     }
-    bool full_iter = !it->Valid() || (strncmp(it->key().data(),prefix.c_str(),2) != 0)
+    bool full_iter = !it->Valid() || (strncmp(it->key().data(),prefix.c_str(),2) != 0);
     if (full_iter && count != g_pserver->cluster->slots_keys_count[hashslot])
     {
         printf("WARNING: rocksdb hashslot count mismatch");

--- a/src/storage/rocksdb.cpp
+++ b/src/storage/rocksdb.cpp
@@ -201,14 +201,13 @@ bool RocksDBStorageProvider::enumerate_hashslot(callback fn, int hashslot) const
         if (!fContinue)
             break;
     }
-    if (!it->Valid() && count != m_count)
+    bool full_iter = !it->Valid() || (strncmp(it->key().data(),prefix.c_str(),2) != 0)
+    if (full_iter && count != g_pserver->cluster->slots_keys_count[hashslot])
     {
-        if (const_cast<RocksDBStorageProvider*>(this)->m_count != count)
-            printf("WARNING: rocksdb count mismatch");
-        const_cast<RocksDBStorageProvider*>(this)->m_count = count;
+        printf("WARNING: rocksdb hashslot count mismatch");
     }
     assert(it->status().ok()); // Check for any errors found during the scan
-    return !it->Valid();
+    return full_iter;
 }
 
 const IStorage *RocksDBStorageProvider::clone() const

--- a/src/storage/rocksdb.h
+++ b/src/storage/rocksdb.h
@@ -48,7 +48,7 @@ public:
     size_t count() const override;
 
 protected:
-    bool FKeyExists(const char *key, size_t cchKey) const;
+    bool FKeyExists(std::string&) const;
 
     const rocksdb::ReadOptions &ReadOptions() const { return m_readOptionsTemplate; }
     rocksdb::WriteOptions WriteOptions() const;

--- a/src/storage/rocksdb.h
+++ b/src/storage/rocksdb.h
@@ -32,7 +32,7 @@ public:
     virtual void retrieve(const char *key, size_t cchKey, callbackSingle fn) const override;
     virtual size_t clear() override;
     virtual bool enumerate(callback fn) const override;
-    virtual bool enumerate_hashslot(callback fn, int hashslot) const override;
+    virtual bool enumerate_hashslot(callback fn, unsigned int hashslot) const override;
 
     virtual const IStorage *clone() const override;
 

--- a/src/storage/rocksdb.h
+++ b/src/storage/rocksdb.h
@@ -32,6 +32,7 @@ public:
     virtual void retrieve(const char *key, size_t cchKey, callbackSingle fn) const override;
     virtual size_t clear() override;
     virtual bool enumerate(callback fn) const override;
+    virtual bool enumerate_hashslot(callback fn, int hashslot) const override;
 
     virtual const IStorage *clone() const override;
 

--- a/src/storage/rocksdbfactory.cpp
+++ b/src/storage/rocksdbfactory.cpp
@@ -71,6 +71,7 @@ RocksDBStorageFactory::RocksDBStorageFactory(const char *dbfile, int dbnum, cons
     rocksdb::DB *db = nullptr;
 
     auto options = RocksDbOptions();
+    options.prefix_extractor.reset(rocksdb::NewFixedPrefixTransform(2));
 
     for (int idb = 0; idb < dbnum; ++idb)
     {

--- a/src/storage/rocksdbfactory.cpp
+++ b/src/storage/rocksdbfactory.cpp
@@ -186,7 +186,7 @@ IStorage *RocksDBStorageFactory::create(int db, key_load_iterator iter, void *pr
                 printf("\tDatabase %d was not shutdown cleanly, recomputing metrics\n", db);
             fFirstRealKey = false;
             if (iter != nullptr)
-                iter(it->key().data(), it->key().size(), privdata);
+                iter(it->key().data()+2, it->key().size()-2, privdata);
             ++count;
         }
     }

--- a/src/storage/teststorageprovider.cpp
+++ b/src/storage/teststorageprovider.cpp
@@ -74,7 +74,7 @@ bool TestStorageProvider::enumerate(callback fn) const
     return fAll;
 }
 
-bool TestStorageProvider::enumerate_hashslot(callback fn, int hashslot) const
+bool TestStorageProvider::enumerate_hashslot(callback fn, unsigned int hashslot) const
 {
     bool fAll = true;
     for (auto &pair : m_map)

--- a/src/storage/teststorageprovider.cpp
+++ b/src/storage/teststorageprovider.cpp
@@ -73,7 +73,22 @@ bool TestStorageProvider::enumerate(callback fn) const
     }
     return fAll;
 }
-    
+
+bool TestStorageProvider::enumerate_hashslot(callback fn, int hashslot) const
+{
+    bool fAll = true;
+    for (auto &pair : m_map)
+    {
+        if (keyHashSlot(pair.first.data(), pair.first.size()) == hashslot)
+            if (!fn(pair.first.data(), pair.first.size(), pair.second.data(), pair.second.size()))
+            {
+                fAll = false;
+                break;
+            }
+    }
+    return fAll;
+}
+      
 size_t TestStorageProvider::count() const
 {
     return m_map.size();

--- a/src/storage/teststorageprovider.h
+++ b/src/storage/teststorageprovider.h
@@ -24,7 +24,7 @@ public:
     virtual void retrieve(const char *key, size_t cchKey, callbackSingle fn) const override;
     virtual size_t clear() override;
     virtual bool enumerate(callback fn) const override;
-    virtual bool enumerate_hashslot(callback fn, int hashslot) const override;
+    virtual bool enumerate_hashslot(callback fn, unsigned int hashslot) const override;
     virtual size_t count() const override;
 
     virtual void flush() override;

--- a/src/storage/teststorageprovider.h
+++ b/src/storage/teststorageprovider.h
@@ -24,6 +24,7 @@ public:
     virtual void retrieve(const char *key, size_t cchKey, callbackSingle fn) const override;
     virtual size_t clear() override;
     virtual bool enumerate(callback fn) const override;
+    virtual bool enumerate_hashslot(callback fn, int hashslot) const override;
     virtual size_t count() const override;
 
     virtual void flush() override;

--- a/tests/instances.tcl
+++ b/tests/instances.tcl
@@ -21,6 +21,7 @@ set ::tls 0
 set ::pause_on_error 0
 set ::dont_clean 0
 set ::simulate_error 0
+set ::flash 0
 set ::failed 0
 set ::sentinel_instances {}
 set ::redis_instances {}
@@ -79,6 +80,10 @@ proc spawn_instance {type base_port count {conf {}} {base_conf_file ""}} {
             set cfg [open $cfgfile a+]
         } else {
             set cfg [open $cfgfile w]
+        }
+
+        if {$::flash} {
+            puts $cfg "storage-provider flash ./flash_$base_port"
         }
 
         if {$::tls} {
@@ -266,6 +271,8 @@ proc parse_options {} {
             set val2 [lindex $::argv [expr $j+2]]
             dict set ::global_config $val $val2
             incr j 2
+        } elseif {$opt eq {--flash}} {
+            set ::flash 1
         } elseif {$opt eq "--help"} {
             puts "--single <pattern>      Only runs tests specified by pattern."
             puts "--dont-clean            Keep log files on exit."
@@ -275,6 +282,7 @@ proc parse_options {} {
             puts "--tls                   Run tests in TLS mode."
             puts "--host <host>           Use hostname instead of 127.0.0.1."
             puts "--config <k> <v>        Extra config argument(s)."
+            puts "--flash                 Run the whole suite with flash enabled"
             puts "--help                  Shows this help."
             exit 0
         } else {

--- a/tests/instances.tcl
+++ b/tests/instances.tcl
@@ -309,11 +309,15 @@ proc pause_on_error {} {
             break
         } elseif {$cmd eq {show-keydb-logs}} {
             set count 10
+            set instance {}
             if {[lindex $argv 1] ne {}} {set count [lindex $argv 1]}
+            if {[lindex $argv 2] ne {}} {set instance [lindex $argv 2]}
             foreach_redis_id id {
-                puts "=== KeyDB $id ===="
-                puts [exec tail -$count redis_$id/log.txt]
-                puts "---------------------\n"
+                if {$instance eq $id || $instance eq {}} {
+                    puts "=== KeyDB $id ===="
+                    puts [exec tail -$count redis_$id/log.txt]
+                    puts "---------------------\n"
+                }
             }
         } elseif {$cmd eq {show-sentinel-logs}} {
             set count 10
@@ -358,7 +362,7 @@ proc pause_on_error {} {
         } elseif {$cmd eq {help}} {
             puts "ls                     List Sentinel and KeyDB instances."
             puts "show-sentinel-logs \[N\] Show latest N lines of logs."
-            puts "show-keydb-logs \[N\]    Show latest N lines of logs."
+            puts "show-keydb-logs \[N\] \[id\]    Show latest N lines of logs of server id."
             puts "S <id> cmd ... arg     Call command in Sentinel <id>."
             puts "R <id> cmd ... arg     Call command in KeyDB <id>."
             puts "SI <id> <field>        Show Sentinel <id> INFO <field>."


### PR DESCRIPTION
This change replaces to the slot_to_key map when flash in enabled by prefixing each key with its hashslot when stored in rocksdb and using rocksdb prefix iter seek to replace functionality of the slot to key map.

Also add --flash option to test scripts to run cluster tests with flash.

maxmemory 100MB, `memtier_benchmark -n 1000000 --cluster`
with change:
```
ALL STATS
======================================================================================================================================================
Type         Ops/sec     Hits/sec   Misses/sec    MOVED/sec      ASK/sec    Avg. Latency     p50 Latency     p99 Latency   p99.9 Latency       KB/sec 
------------------------------------------------------------------------------------------------------------------------------------------------------
Sets        20330.84          ---          ---         0.00         0.00         2.71533         2.31900         8.70300        14.07900      1566.28 
Gets       203306.19    192656.60     10649.59         0.00         0.00         2.65851         2.27100         8.63900        14.01500     14316.36 
Waits           0.00          ---          ---          ---          ---             ---             ---             ---             ---          --- 
Totals     223637.03    192656.60     10649.59         0.00         0.00         2.66367         2.27100         8.63900        14.01500     15882.64 
```
without change:
```
ALL STATS
======================================================================================================================================================
Type         Ops/sec     Hits/sec   Misses/sec    MOVED/sec      ASK/sec    Avg. Latency     p50 Latency     p99 Latency   p99.9 Latency       KB/sec 
------------------------------------------------------------------------------------------------------------------------------------------------------
Sets         5428.89          ---          ---         0.00         0.00         9.15187         2.01500       202.75100       313.34300       418.24 
Gets        54288.30     51452.47      2835.83         0.00         0.00         8.99135         1.96700       200.70300       313.34300      3823.12 
Waits           0.00          ---          ---          ---          ---             ---             ---             ---             ---          --- 
Totals      59717.19     51452.47      2835.83         0.00         0.00         9.00595         1.96700       200.70300       313.34300      4241.36 
```
Fixes #646.