### PR TITLE
Fix aws s3 startup check preventing keydb from starting

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -2468,7 +2468,7 @@ static int isValidS3Bucket(char *s3bucket, const char **err) {
 
     if (pid == 0)
     {
-        execlp("aws", "aws", "s3", "ls", s3bucket);
+        execlp("aws", "aws", "s3", "ls", s3bucket, nullptr);
         exit(EXIT_FAILURE);
     }
     else 


### PR DESCRIPTION
During startup, when db-s3-object is set, keydb can't start and gets into error
"could not access s3 bucket"
