### PR TITLE
keys after brpop causes crash due to timeout not being reset

### DIFF
--- a/src/blocked.cpp
+++ b/src/blocked.cpp
@@ -732,6 +732,7 @@ void unblockClientWaitingData(client *c) {
         c->bpop.xread_group = NULL;
         c->bpop.xread_consumer = NULL;
     }
+    c->bpop.timeout = 0;
 }
 
 static int getBlockedTypeByType(int type) {

--- a/tests/unit/type/list.tcl
+++ b/tests/unit/type/list.tcl
@@ -1069,6 +1069,13 @@ start_server {
         r ping
     } {PONG}
 
+    test "Regression for bug 659 - chaining BRPOP with async blocking cmds" {
+        r flushall
+        r brpop foo 1
+        r keys *
+        r ping
+    } {PONG}
+
     test "client unblock tests" {
         r del l
         set rd [redis_deferring_client]


### PR DESCRIPTION
Fixes #659. Fixes #605. Fixes #532.