### PR TITLE
Throw load error when replicaof config is before active-replica or multi-master configs

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -749,7 +749,7 @@ void loadServerConfigFromString(char *config) {
                 g_pserver->fActiveReplica = CONFIG_DEFAULT_ACTIVE_REPLICA;
                 err = "argument must be 'yes' or 'no'"; goto loaderr;
             }
-            if (listLength(g_pserver->masters)) {
+            if (listLength(g_pserver->masters) && g_pserver->fActiveReplica) {
                 err = "must not set replica-of config before active-replica config"; goto loaderr;
             }
         } else if (!strcasecmp(argv[0], "multi-master") && argc == 2) {
@@ -758,7 +758,7 @@ void loadServerConfigFromString(char *config) {
                 g_pserver->enable_multimaster = CONFIG_DEFAULT_ENABLE_MULTIMASTER;
                 err = "argument must be 'yes' or 'no'"; goto loaderr;
             }
-            if (listLength(g_pserver->masters)) {
+            if (listLength(g_pserver->masters) && g_pserver->enable_multimaster) {
                 err = "must not set replica-of config before multi-master config"; goto loaderr;
             }
         } else if (!strcasecmp(argv[0], "tls-allowlist")) {

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -749,6 +749,18 @@ void loadServerConfigFromString(char *config) {
                 g_pserver->fActiveReplica = CONFIG_DEFAULT_ACTIVE_REPLICA;
                 err = "argument must be 'yes' or 'no'"; goto loaderr;
             }
+            if (listLength(g_pserver->masters)) {
+                err = "must not set replica-of config before active-replica config"; goto loaderr;
+            }
+        } else if (!strcasecmp(argv[0], "multi-master") && argc == 2) {
+            g_pserver->enable_multimaster = yesnotoi(argv[1]);
+            if (g_pserver->enable_multimaster == -1) {
+                g_pserver->enable_multimaster = CONFIG_DEFAULT_ENABLE_MULTIMASTER;
+                err = "argument must be 'yes' or 'no'"; goto loaderr;
+            }
+            if (listLength(g_pserver->masters)) {
+                err = "must not set replica-of config before multi-master config"; goto loaderr;
+            }
         } else if (!strcasecmp(argv[0], "tls-allowlist")) {
             if (argc < 2) {
                 err = "must supply at least one element in the allow list"; goto loaderr;
@@ -2798,7 +2810,6 @@ standardConfig configs[] = {
     createBoolConfig("replica-serve-stale-data", "slave-serve-stale-data", MODIFIABLE_CONFIG, g_pserver->repl_serve_stale_data, 1, NULL, NULL),
     createBoolConfig("replica-read-only", "slave-read-only", MODIFIABLE_CONFIG, g_pserver->repl_slave_ro, 1, NULL, NULL),
     createBoolConfig("replica-ignore-maxmemory", "slave-ignore-maxmemory", MODIFIABLE_CONFIG, g_pserver->repl_slave_ignore_maxmemory, 1, NULL, NULL),
-    createBoolConfig("multi-master", NULL, IMMUTABLE_CONFIG, g_pserver->enable_multimaster,CONFIG_DEFAULT_ENABLE_MULTIMASTER, NULL, NULL),
     createBoolConfig("jemalloc-bg-thread", NULL, MODIFIABLE_CONFIG, cserver.jemalloc_bg_thread, 1, NULL, updateJemallocBgThread),
     createBoolConfig("activedefrag", NULL, MODIFIABLE_CONFIG, cserver.active_defrag_enabled, 0, isValidActiveDefrag, NULL),
     createBoolConfig("syslog-enabled", NULL, IMMUTABLE_CONFIG, g_pserver->syslog_enabled, 0, NULL, NULL),


### PR DESCRIPTION
Multi-master doesn't work correctly if the configs are not set in the right order, so throw a load error rather than allow the user to start up with a bad config and have an incorrectly functioning server.

https://docs.keydb.dev/docs/multi-master/#config-file

Fixes #665.