### PR TITLE
Update RPM script for Rocky Linux 9

### DIFF
--- a/pkg/rpm/generate_rpms.sh
+++ b/pkg/rpm/generate_rpms.sh
@@ -5,10 +5,7 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 version=$(grep KEYDB_REAL_VERSION $DIR/../../src/version.h | awk '{ printf $3 }' | tr -d \")
 release=1 # by default this will always be 1 for keydb version structure. If build release version needs to be update you can modify here
 arch=$(uname -m)
-dist=el$(rpm -q --queryformat '%{VERSION}' centos-release | cut -d. -f1)
-if [[ "$dist" == "elpackage centos-release is not installed" ]]; then
-        dist=el$(rpm -q --queryformat '%{VERSION}' centos-linux-release  | cut -d. -f1)
-fi
+dist=$(rpm --eval '%{?dist}')
 
 if [[ "$arch" != "aarch64" ]] && [[ "$arch" != "x86_64" ]]; then
 	echo "This script is only valid and tested for aarch64 and x86_64 architectures. You are trying to use: $arch"
@@ -39,8 +36,8 @@ sed -i -E "1a\Version     : $version" $DIR/keydb_build/keydb.spec
 sed -i '3d' $DIR/keydb_build/keydb.spec
 sed -i -E "2a\Release     : $release%{?dist}" $DIR/keydb_build/keydb.spec
 
-mkdir -p /root/rpmbuild/BUILDROOT/keydb-$version-$release.$dist.$arch
-cp -r $DIR/keydb_build/keydb_rpm/* /root/rpmbuild/BUILDROOT/keydb-$version-$release.$dist.$arch/
+mkdir -p /root/rpmbuild/BUILDROOT/keydb-$version-$release$dist.$arch
+cp -r $DIR/keydb_build/keydb_rpm/* /root/rpmbuild/BUILDROOT/keydb-$version-$release$dist.$arch/
 rpmbuild -bb $DIR/keydb_build/keydb.spec
 mv /root/rpmbuild/RPMS/$arch/* $DIR/rpm_files_generated
 


### PR DESCRIPTION
KeyDB compiles on Rocky Linux 9 and 'make test' passes completely. However, the RPM package generation script was incompatible, as it relied on the version information of CentOS packages that were not available on Rocky Linux. This pull request uses the 'dist' RPM macro instead, which works on CentOS 7 and 8 as well.

This should work on CentOS Stream 9, RHEL 9, and variants like AlmaLinux 9 as well. Hopefully, there is going to be official RPM packages for these systems.