### PR TITLE
Fix a bug where a temp rdb file with zero bytes is generated in flash mode

### DIFF
--- a/src/replication.cpp
+++ b/src/replication.cpp
@@ -3732,7 +3732,7 @@ retry_connect:
     }
 
     /* Prepare a suitable temp file for bulk transfer */
-    if (!useDisklessLoad()) {
+    if (!useDisklessLoad() && !mi->isRocksdbSnapshotRepl) {
         while(maxtries--) {
             auto dt = std::chrono::system_clock::now().time_since_epoch();
             auto dtMillisecond = std::chrono::duration_cast<std::chrono::milliseconds>(dt);


### PR DESCRIPTION
This is a possible fix for the issue https://github.com/Snapchat/KeyDB/issues/695, as it skips temp rdb file creation with zero bytes when the rocksdb snapshot replication is enabled.

@JohnSully / @msotheeswaran Could you please review the changes and merge? thanks.

@paulmchen @hengku @yzhao244
