### PR TITLE
Fix integer overflow issue in the temp rdb file naming

### DIFF
--- a/src/replication.cpp
+++ b/src/replication.cpp
@@ -3738,7 +3738,7 @@ retry_connect:
             auto dt = std::chrono::system_clock::now().time_since_epoch();
             auto dtMillisecond = std::chrono::duration_cast<std::chrono::milliseconds>(dt);
             snprintf(tmpfile,sizeof(tmpfile),
-                "temp-%d.%ld.rdb",(int)dtMillisecond.count(),(long int)getpid());
+                "temp-%lld.%ld.rdb",(long long)dtMillisecond.count(),(long int)getpid());
             dfd = open(tmpfile,O_CREAT|O_WRONLY|O_EXCL,0644);
             if (dfd != -1) break;
             sleep(1);


### PR DESCRIPTION
This is to fix a bug related to integer overflow issue in the temp rdb file naming, especially in the current time (in milliseconds) portion in the file name.

It is possible that the temp rdb file name (i.e., `temp-<timestamp>.<pid>.rdb`) might have incorrect (possibly negative) timestamp value. Therefore, it is preferred to change the data type to `long long` to be at least 64 bits in length.

An example current time in milliseconds = 1690471817044.

@JohnSully / @msotheeswaran-sc could you please review and merge? thanks.

@paulmchen @hengku @yzhao244