### PR TITLE
Fixing some compile issues for alpine and centos, also fix endian issue for FLASH hashslot prefix

### DIFF
--- a/pkg/docker/Dockerfile_Alpine
+++ b/pkg/docker/Dockerfile_Alpine
@@ -1,4 +1,4 @@
-FROM alpine:3.12
+FROM alpine:3.18
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
 RUN addgroup -S -g 1000 keydb && adduser -S -G keydb -u 999 keydb
 RUN mkdir -p /etc/keydb

--- a/src/Makefile
+++ b/src/Makefile
@@ -358,6 +358,7 @@ endif
 OS := $(shell cat /etc/os-release | grep ID= | head -n 1 | cut -d'=' -f2)
 ifeq ($(OS),alpine)
     FINAL_CXXFLAGS+=-DUNW_LOCAL_ONLY
+	FINAL_CXXFLAGS+=-DALPINE
     FINAL_LIBS += -lunwind
 endif
 

--- a/src/readwritelock.h
+++ b/src/readwritelock.h
@@ -42,9 +42,9 @@ public:
             while (m_readCount > 0)
                 m_cv.wait(rm);
             if (exclusive) {
-                /* Another thread might have the write lock while we have the read lock
-                but won't be able to release it until they can acquire the read lock
-                so release the read lock and try again instead of waiting to avoid deadlock */
+                /* Another thread might have the write lock while we have the internal lock
+                but won't be able to release it until they can acquire the internal lock
+                so release the internal lock and try again instead of waiting to avoid deadlock */
                 while(!m_writeLock.try_lock())
                     m_cv.wait(rm);
             }

--- a/src/server.h
+++ b/src/server.h
@@ -3923,7 +3923,7 @@ void updateActiveReplicaMastersFromRsi(rdbSaveInfo *rsi);
 uint64_t getMvccTstamp();
 void incrementMvccTstamp();
 
-#if __GNUC__ >= 7 && !defined(NO_DEPRECATE_FREE)
+#if __GNUC__ >= 7 && !defined(NO_DEPRECATE_FREE) && !defined(ALPINE)
  [[deprecated]]
 void *calloc(size_t count, size_t size) noexcept;
  [[deprecated]]

--- a/src/storage/rocksdb.cpp
+++ b/src/storage/rocksdb.cpp
@@ -208,7 +208,7 @@ bool RocksDBStorageProvider::enumerate_hashslot(callback fn, unsigned int hashsl
     for (it->Seek(prefix); it->Valid(); it->Next()) {
         if (FInternalKey(it->key().data(), it->key().size()))
             continue;
-        if ((unsigned int)*it->key().data() != hashslot)
+        if (*(unsigned int *)it->key().data() != hashslot)
             break;
         ++count;
         bool fContinue = fn(it->key().data()+sizeof(unsigned int), it->key().size()-sizeof(unsigned int), it->value().data(), it->value().size());

--- a/src/storage/rocksdb.cpp
+++ b/src/storage/rocksdb.cpp
@@ -214,10 +214,8 @@ bool RocksDBStorageProvider::enumerate_hashslot(callback fn, unsigned int hashsl
         bool fContinue = fn(it->key().data()+sizeof(unsigned int), it->key().size()-sizeof(unsigned int), it->value().data(), it->value().size());
         if (!fContinue)
             break;
-        serverLog(LL_WARNING, "%d %d %d", hashslot, (unsigned int)*it->key().data(), (unsigned int)*prefix.c_str());
-        serverLog(LL_WARNING, "Found key %d of %d with len %d: %.*s", count, g_pserver->cluster->slots_keys_count[hashslot], (int)it->key().size()-sizeof(unsigned int), (int)it->key().size()-sizeof(unsigned int), it->key().data()+sizeof(unsigned int));
     }
-    bool full_iter = !it->Valid() || (strncmp(it->key().data(),prefix.c_str(),2) != 0);
+    bool full_iter = !it->Valid() || (*(unsigned int *)it->key().data() != hashslot);
     if (full_iter && count != g_pserver->cluster->slots_keys_count[hashslot])
     {
         printf("WARNING: rocksdb hashslot count mismatch");

--- a/src/storage/rocksdb.cpp
+++ b/src/storage/rocksdb.cpp
@@ -208,7 +208,7 @@ bool RocksDBStorageProvider::enumerate_hashslot(callback fn, unsigned int hashsl
     for (it->Seek(prefix); it->Valid(); it->Next()) {
         if (FInternalKey(it->key().data(), it->key().size()))
             continue;
-        if (strncmp(it->key().data(),prefix.c_str(),sizeof(unsigned int)) != 0)
+        if ((unsigned int)*it->key().data() != hashslot)
             break;
         ++count;
         bool fContinue = fn(it->key().data()+sizeof(unsigned int), it->key().size()-sizeof(unsigned int), it->value().data(), it->value().size());

--- a/src/storage/rocksdb.cpp
+++ b/src/storage/rocksdb.cpp
@@ -7,6 +7,8 @@
 #include "../cluster.h"
 #include "rocksdbfactor_internal.h"
 
+template class std::basic_string<char>;
+
 static const char keyprefix[] = INTERNAL_KEY_PREFIX;
 
 rocksdb::Options DefaultRocksDBOptions();

--- a/src/storage/rocksdb.cpp
+++ b/src/storage/rocksdb.cpp
@@ -214,7 +214,7 @@ bool RocksDBStorageProvider::enumerate_hashslot(callback fn, unsigned int hashsl
         bool fContinue = fn(it->key().data()+sizeof(unsigned int), it->key().size()-sizeof(unsigned int), it->value().data(), it->value().size());
         if (!fContinue)
             break;
-        serverLog(LL_WARNING, "%d %d", hashslot, *it->key().data());
+        serverLog(LL_WARNING, "%d %d %d", hashslot, *it->key().data(), *prefix.c_str());
         serverLog(LL_WARNING, "Found key %d of %d with len %d: %.*s", count, g_pserver->cluster->slots_keys_count[hashslot], (int)it->key().size()-sizeof(unsigned int), (int)it->key().size()-sizeof(unsigned int), it->key().data()+sizeof(unsigned int));
     }
     bool full_iter = !it->Valid() || (strncmp(it->key().data(),prefix.c_str(),2) != 0);

--- a/src/storage/rocksdb.cpp
+++ b/src/storage/rocksdb.cpp
@@ -214,7 +214,7 @@ bool RocksDBStorageProvider::enumerate_hashslot(callback fn, unsigned int hashsl
         bool fContinue = fn(it->key().data()+sizeof(unsigned int), it->key().size()-sizeof(unsigned int), it->value().data(), it->value().size());
         if (!fContinue)
             break;
-        serverLog(LL_WARNING, "%d %d %d", hashslot, *it->key().data(), *prefix.c_str());
+        serverLog(LL_WARNING, "%d %d %d", hashslot, (unsigned int)*it->key().data(), (unsigned int)*prefix.c_str());
         serverLog(LL_WARNING, "Found key %d of %d with len %d: %.*s", count, g_pserver->cluster->slots_keys_count[hashslot], (int)it->key().size()-sizeof(unsigned int), (int)it->key().size()-sizeof(unsigned int), it->key().data()+sizeof(unsigned int));
     }
     bool full_iter = !it->Valid() || (strncmp(it->key().data(),prefix.c_str(),2) != 0);

--- a/src/storage/rocksdb.cpp
+++ b/src/storage/rocksdb.cpp
@@ -3,7 +3,6 @@
 #include <sstream>
 #include <mutex>
 #include <unistd.h>
-#include <arpa/inet.h>
 #include "../server.h"
 #include "../cluster.h"
 #include "rocksdbfactor_internal.h"
@@ -231,7 +230,7 @@ void RocksDBStorageProvider::setExpire(const char *key, size_t cchKey, long long
 {
     rocksdb::Status status;
     std::unique_lock<fastlock> l(m_lock);
-    long long beExpire = htonll(expire);
+    long long beExpire = htobe64(expire);
     std::string prefix((const char *)&beExpire,sizeof(long long));
     std::string strKey(key, cchKey);
     if (m_spbatch != nullptr)
@@ -246,7 +245,7 @@ void RocksDBStorageProvider::removeExpire(const char *key, size_t cchKey, long l
 {
     rocksdb::Status status;
     std::unique_lock<fastlock> l(m_lock);
-    long long beExpire = htonll(expire);
+    long long beExpire = htobe64(expire);
     std::string prefix((const char *)&beExpire,sizeof(long long));
     std::string strKey(key, cchKey);
     std::string fullKey = prefix + strKey;

--- a/src/storage/rocksdb.cpp
+++ b/src/storage/rocksdb.cpp
@@ -3,6 +3,7 @@
 #include <sstream>
 #include <mutex>
 #include <unistd.h>
+#include <arpa/inet.h>
 #include "../server.h"
 #include "../cluster.h"
 #include "rocksdbfactor_internal.h"
@@ -230,7 +231,8 @@ void RocksDBStorageProvider::setExpire(const char *key, size_t cchKey, long long
 {
     rocksdb::Status status;
     std::unique_lock<fastlock> l(m_lock);
-    std::string prefix((const char *)&expire,sizeof(long long));
+    long long beExpire = htonll(expire);
+    std::string prefix((const char *)&beExpire,sizeof(long long));
     std::string strKey(key, cchKey);
     if (m_spbatch != nullptr)
         status = m_spbatch->Put(m_spexpirecolfamily.get(), rocksdb::Slice(prefix + strKey), rocksdb::Slice(strKey));
@@ -244,7 +246,8 @@ void RocksDBStorageProvider::removeExpire(const char *key, size_t cchKey, long l
 {
     rocksdb::Status status;
     std::unique_lock<fastlock> l(m_lock);
-    std::string prefix((const char *)&expire,sizeof(long long));
+    long long beExpire = htonll(expire);
+    std::string prefix((const char *)&beExpire,sizeof(long long));
     std::string strKey(key, cchKey);
     std::string fullKey = prefix + strKey;
     if (!FExpireExists(fullKey))

--- a/src/storage/rocksdb.h
+++ b/src/storage/rocksdb.h
@@ -4,11 +4,14 @@
 #include "../IStorage.h"
 #include <rocksdb/db.h>
 #include <rocksdb/utilities/write_batch_with_index.h>
+#include <endian.h>
 #include "../fastlock.h"
 
 #define INTERNAL_KEY_PREFIX "\x00\x04\x03\x00\x05\x02\x04"
 #define HASHSLOT_PREFIX_TYPE uint16_t
 #define HASHSLOT_PREFIX_BYTES sizeof(HASHSLOT_PREFIX_TYPE)
+#define HASHSLOT_PREFIX_ENDIAN htole16
+#define HASHSLOT_PREFIX_RECOVER le16toh
 static const char count_key[] = INTERNAL_KEY_PREFIX "__keydb__count\1";
 static const char version_key[] = INTERNAL_KEY_PREFIX "__keydb__version\1";
 static const char meta_key[] = INTERNAL_KEY_PREFIX "__keydb__metadata\1";

--- a/src/storage/rocksdb.h
+++ b/src/storage/rocksdb.h
@@ -6,8 +6,9 @@
 #include <rocksdb/utilities/write_batch_with_index.h>
 #ifdef __APPLE__
 #include <libkern/OSByteOrder.h>
-#define htole16(x) OSSwapHostToLittleInt16(x)
-#define le16toh(x) OSSwapLittleToHostInt16(x)
+#define htole16 OSSwapHostToLittleInt16
+#define le16toh OSSwapLittleToHostInt16
+#define htobe64 OSSwapHostToBigInt64
 #else
 #include <endian.h>
 #endif

--- a/src/storage/rocksdb.h
+++ b/src/storage/rocksdb.h
@@ -7,6 +7,8 @@
 #include "../fastlock.h"
 
 #define INTERNAL_KEY_PREFIX "\x00\x04\x03\x00\x05\x02\x04"
+#define HASHSLOT_PREFIX_TYPE uint16_t
+#define HASHSLOT_PREFIX_BYTES sizeof(HASHSLOT_PREFIX_TYPE)
 static const char count_key[] = INTERNAL_KEY_PREFIX "__keydb__count\1";
 static const char version_key[] = INTERNAL_KEY_PREFIX "__keydb__version\1";
 static const char meta_key[] = INTERNAL_KEY_PREFIX "__keydb__metadata\1";

--- a/src/storage/rocksdb.h
+++ b/src/storage/rocksdb.h
@@ -4,7 +4,13 @@
 #include "../IStorage.h"
 #include <rocksdb/db.h>
 #include <rocksdb/utilities/write_batch_with_index.h>
+#ifdef __APPLE__
+#include <libkern/OSByteOrder.h>
+#define htole16(x) OSSwapHostToLittleInt16(x)
+#define le16toh(x) OSSwapLittleToHostInt16(x)
+#else
 #include <endian.h>
+#endif
 #include "../fastlock.h"
 
 #define INTERNAL_KEY_PREFIX "\x00\x04\x03\x00\x05\x02\x04"

--- a/src/storage/rocksdbfactory.cpp
+++ b/src/storage/rocksdbfactory.cpp
@@ -72,7 +72,7 @@ RocksDBStorageFactory::RocksDBStorageFactory(const char *dbfile, int dbnum, cons
     rocksdb::DB *db = nullptr;
 
     auto options = RocksDbOptions();
-    options.prefix_extractor.reset(rocksdb::NewFixedPrefixTransform(sizeof(unsigned int)));
+    options.prefix_extractor.reset(rocksdb::NewFixedPrefixTransform(HASHSLOT_PREFIX_BYTES));
 
     for (int idb = 0; idb < dbnum; ++idb)
     {
@@ -196,7 +196,7 @@ IStorage *RocksDBStorageFactory::create(int db, key_load_iterator iter, void *pr
                 printf("\tDatabase %d was not shutdown cleanly, recomputing metrics\n", db);
             fFirstRealKey = false;
             if (iter != nullptr)
-                iter(it->key().data()+sizeof(unsigned int), it->key().size()-sizeof(unsigned int), privdata);
+                iter(it->key().data()+HASHSLOT_PREFIX_BYTES, it->key().size()-HASHSLOT_PREFIX_BYTES, privdata);
             ++count;
         }
     }

--- a/src/storage/rocksdbfactory.cpp
+++ b/src/storage/rocksdbfactory.cpp
@@ -72,7 +72,7 @@ RocksDBStorageFactory::RocksDBStorageFactory(const char *dbfile, int dbnum, cons
     rocksdb::DB *db = nullptr;
 
     auto options = RocksDbOptions();
-    options.prefix_extractor.reset(rocksdb::NewFixedPrefixTransform(2));
+    options.prefix_extractor.reset(rocksdb::NewFixedPrefixTransform(sizeof(unsigned int)));
 
     for (int idb = 0; idb < dbnum; ++idb)
     {

--- a/src/storage/rocksdbfactory.cpp
+++ b/src/storage/rocksdbfactory.cpp
@@ -196,7 +196,7 @@ IStorage *RocksDBStorageFactory::create(int db, key_load_iterator iter, void *pr
                 printf("\tDatabase %d was not shutdown cleanly, recomputing metrics\n", db);
             fFirstRealKey = false;
             if (iter != nullptr)
-                iter(it->key().data()+2, it->key().size()-2, privdata);
+                iter(it->key().data()+sizeof(unsigned int), it->key().size()-sizeof(unsigned int), privdata);
             ++count;
         }
     }


### PR DESCRIPTION
Current implementation of hash slot prefix resulted in incorrect enumeration due to using the wrong 2 bytes, so just use the whole value.
Fixes issue #677.
also update alpine version in Dockerfile Fixes issue #721.