### PR TITLE
Merge `RUN` commands, remove unnecessary `grep` commands, remove redundancy. 

### DIFF
--- a/machamp_scripts/Dockerfile
+++ b/machamp_scripts/Dockerfile
@@ -1,114 +1,101 @@
 FROM ubuntu:20.04
-SHELL ["/bin/bash","-c"]
+
+SHELL ["/bin/bash", "-c"]
+
+# Set up keydb user and group
 RUN groupadd -r keydb && useradd -r -g keydb keydb
-# use gosu for easy step-down from root: https://github.com/tianon/gosu/releases
+
+# Install gosu for easy step-down from root
 ENV GOSU_VERSION 1.14
 RUN set -eux; \
-        savedAptMark="$(apt-mark showmanual)"; \
-        apt-get update; \
-        apt-get -o Dpkg::Options::="--force-confnew" install -y --no-install-recommends ca-certificates dirmngr gnupg wget; \
-        rm -rf /var/lib/apt/lists/*; \
-        dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
-        wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch"; \
-        wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc"; \
-        export GNUPGHOME="$(mktemp -d)"; \
-        gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
-        gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
-        gpgconf --kill all; \
-        rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc; \
-        apt-mark auto '.*' > /dev/null; \
-        [ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; \
-        apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
-        chmod +x /usr/local/bin/gosu; \
-        gosu --version; \
-        gosu nobody true
-# build KeyDB
+    savedAptMark="$(apt-mark showmanual)"; \
+    apt-get update; \
+    apt-get -o Dpkg::Options::="--force-confnew" install -y --no-install-recommends ca-certificates dirmngr gnupg wget; \
+    rm -rf /var/lib/apt/lists/*; \
+    dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
+    wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch"; \
+    wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc"; \
+    export GNUPGHOME="$(mktemp -d)"; \
+    gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
+    gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
+    gpgconf --kill all; \
+    rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc; \
+    apt-mark auto '.*' > /dev/null; \
+    [ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; \
+    apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+    chmod +x /usr/local/bin/gosu; \
+    gosu --version; \
+    gosu nobody true
+
+# Build KeyDB
 ARG MAKE_JOBS=""
 ARG ENABLE_FLASH=""
+
 COPY . /tmp/keydb-internal
+
 RUN set -eux; \
-        cd /tmp/keydb-internal; \
-        savedAptMark="$(apt-mark showmanual)"; \
-        apt-get update; \
-        DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confnew" install -qqy --no-install-recommends \
-                dpkg-dev \
-                pkg-config \
-                ca-certificates \
-                build-essential \
-                nasm \
-                autotools-dev \
-                autoconf \
-                libjemalloc-dev \
-                tcl \
-                tcl-dev \
-                uuid-dev \
-                libcurl4-openssl-dev \
-                libbz2-dev \
-                libzstd-dev \
-                liblz4-dev \
-                libsnappy-dev \
-                libssl-dev \
-                git; \
-        # disable protected mode as it relates to docker
-        grep -E '^ *createBoolConfig[(]"protected-mode",.*, *1 *,.*[)],$' ./src/config.cpp; \
-        sed -ri 's!^( *createBoolConfig[(]"protected-mode",.*, *)1( *,.*[)],)$!\10\2!' ./src/config.cpp; \
-        grep -E '^ *createBoolConfig[(]"protected-mode",.*, *0 *,.*[)],$' ./src/config.cpp; \
-        make distclean; \
-        make -j$([ -z "$MAKE_JOBS" ] &&  nproc || echo "$MAKE_JOBS") BUILD_TLS=yes NO_LICENSE_CHECK=yes $([ -z "$ENABLE_FLASH" ] &&  echo "" || echo "ENABLE_FLASH=$ENABLE_FLASH"); \
-        cd src; \
-        mv modules/keydb_modstatsd/modstatsd.so /usr/local/lib/; \
-        strip keydb-cli keydb-benchmark keydb-check-rdb keydb-check-aof keydb-diagnostic-tool keydb-sentinel; \
-        mv keydb-server keydb-cli keydb-benchmark keydb-check-rdb keydb-check-aof keydb-diagnostic-tool keydb-sentinel /usr/local/bin/; \
-        # clean up unused dependencies
-        echo $savedAptMark; \
-        apt-mark auto '.*' > /dev/null; \
-        [ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; \
-        find /usr/local -type f -executable -exec ldd '{}' ';' \
-               | awk '/=>/ { print $(NF-1) }' \
-               | sed 's:.*/::' \
-               | sort -u \
-               | xargs -r dpkg-query --search \
-               | cut -d: -f1 \
-               | sort -u \
-               | xargs -r apt-mark manual \
-        ; \
-        apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
-        rm -rf /var/lib/apt/lists/*; \
-# create working directories and organize files
-RUN \
-        mkdir /data && chown keydb:keydb /data; \
-        mkdir /flash && chown keydb:keydb /flash; \
-        mkdir -p /etc/keydb; \
-        cp /tmp/keydb-internal/keydb.conf /etc/keydb/; \
-        sed -i 's/^\(daemonize .*\)$/# \1/' /etc/keydb/keydb.conf; \
-        sed -i 's/^\(dir .*\)$/# \1\ndir \/data/' /etc/keydb/keydb.conf; \
-        sed -i 's/^\(logfile .*\)$/# \1/' /etc/keydb/keydb.conf; \
-        sed -i 's/protected-mode yes/protected-mode no/g' /etc/keydb/keydb.conf; \
-        sed -i 's/^\(bind .*\)$/# \1/' /etc/keydb/keydb.conf; \
-        echo -e "\nloadmodule /usr/local/lib/modstatsd.so" >> /etc/keydb/keydb.conf; \
-	ln -s keydb-cli redis-cli; \
-        cd /etc/keydb; \
-        ln -s keydb.conf redis.conf; \
-        rm -rf /tmp/*
-# generate entrypoint script
+    cd /tmp/keydb-internal; \
+    savedAptMark="$(apt-mark showmanual)"; \
+    apt-get update; \
+    DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confnew" install -qqy --no-install-recommends \
+        dpkg-dev pkg-config ca-certificates build-essential nasm autotools-dev autoconf libjemalloc-dev tcl tcl-dev \
+        uuid-dev libcurl4-openssl-dev libbz2-dev libzstd-dev liblz4-dev libsnappy-dev libssl-dev git; \
+    # Disable protected mode
+    sed -ri 's!^( *createBoolConfig[(]"protected-mode",.*, *)1( *,.*[)],)$!\10\2!' ./src/config.cpp; \
+    make distclean; \
+    make -j$([ -z "$MAKE_JOBS" ] && nproc || echo "$MAKE_JOBS") BUILD_TLS=yes NO_LICENSE_CHECK=yes $([ -z "$ENABLE_FLASH" ] && echo "" || echo "ENABLE_FLASH=$ENABLE_FLASH"); \
+    cd src; \
+    mv modules/keydb_modstatsd/modstatsd.so /usr/local/lib/; \
+    strip keydb-cli keydb-benchmark keydb-check-rdb keydb-check-aof keydb-diagnostic-tool keydb-sentinel; \
+    mv keydb-server keydb-cli keydb-benchmark keydb-check-rdb keydb-check-aof keydb-diagnostic-tool keydb-sentinel /usr/local/bin/; \
+    apt-mark auto '.*' > /dev/null; \
+    [ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; \
+    find /usr/local -type f -executable -exec ldd '{}' ';' \
+        | awk '/=>/ { print $(NF-1) }' \
+        | sed 's:.*/::' | sort -u | xargs -r dpkg-query --search \
+        | cut -d: -f1 | sort -u | xargs -r apt-mark manual; \
+    apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+    rm -rf /var/lib/apt/lists/*
+
+# Set up working directories and configuration
+RUN mkdir /data && chown keydb:keydb /data; \
+    mkdir /flash && chown keydb:keydb /flash; \
+    mkdir -p /etc/keydb; \
+    cp /tmp/keydb-internal/keydb.conf /etc/keydb/; \
+    sed -i 's/^\(daemonize .*\)$/# \1/' /etc/keydb/keydb.conf; \
+    sed -i 's/^\(dir .*\)$/# \1\ndir \/data/' /etc/keydb/keydb.conf; \
+    sed -i 's/^\(logfile .*\)$/# \1/' /etc/keydb/keydb.conf; \
+    sed -i 's/protected-mode yes/protected-mode no/g' /etc/keydb/keydb.conf; \
+    sed -i 's/^\(bind .*\)$/# \1/' /etc/keydb/keydb.conf; \
+    echo -e "\nloadmodule /usr/local/lib/modstatsd.so" >> /etc/keydb/keydb.conf; \
+    ln -s keydb-cli redis-cli; \
+    cd /etc/keydb; \
+    ln -s keydb.conf redis.conf; \
+    rm -rf /tmp/*
+
+# Generate entrypoint script
 RUN set -eux; \
-        echo '#!/bin/sh' > /usr/local/bin/docker-entrypoint.sh; \
-        echo 'set -e' >> /usr/local/bin/docker-entrypoint.sh; \
-        echo "# perpend 'keydb-server' if not provided as first argument" >> /usr/local/bin/docker-entrypoint.sh; \
-        echo 'if [ "${1}" != "keydb-server" ]; then' >> /usr/local/bin/docker-entrypoint.sh; \
-        echo '        set -- keydb-server "$@"' >> /usr/local/bin/docker-entrypoint.sh; \
-        echo 'fi' >> /usr/local/bin/docker-entrypoint.sh; \
-        echo "# allow the container to be started with `--user`" >> /usr/local/bin/docker-entrypoint.sh; \
-        echo 'if [ "$1" = "keydb-server" -a "$(id -u)" = "0" ]; then' >> /usr/local/bin/docker-entrypoint.sh; \
-        echo "        find . \! -user keydb -exec chown keydb '{}' +" >> /usr/local/bin/docker-entrypoint.sh; \
-        echo '        exec gosu keydb "$0" "$@"' >> /usr/local/bin/docker-entrypoint.sh; \
-        echo 'fi' >> /usr/local/bin/docker-entrypoint.sh; \
-        echo 'exec "$@"' >> /usr/local/bin/docker-entrypoint.sh; \
-        chmod +x /usr/local/bin/docker-entrypoint.sh
-# set remaining image properties
+    echo '#!/bin/sh' > /usr/local/bin/docker-entrypoint.sh; \
+    echo 'set -e' >> /usr/local/bin/docker-entrypoint.sh; \
+    echo "# prepend 'keydb-server' if not provided as first argument" >> /usr/local/bin/docker-entrypoint.sh; \
+    echo 'if [ "${1}" != "keydb-server" ]; then' >> /usr/local/bin/docker-entrypoint.sh; \
+    echo '    set -- keydb-server "$@"' >> /usr/local/bin/docker-entrypoint.sh; \
+    echo 'fi' >> /usr/local/bin/docker-entrypoint.sh; \
+    echo "# allow the container to be started with `--user`" >> /usr/local/bin/docker-entrypoint.sh; \
+    echo 'if [ "$1" = "keydb-server" -a "$(id -u)" = "0" ]; then' >> /usr/local/bin/docker-entrypoint.sh; \
+    echo '    find . \! -user keydb -exec chown keydb "{}" +' >> /usr/local/bin/docker-entrypoint.sh; \
+    echo '    exec gosu keydb "$0" "$@"' >> /usr/local/bin/docker-entrypoint.sh; \
+    echo 'fi' >> /usr/local/bin/docker-entrypoint.sh; \
+    echo 'exec "$@"' >> /usr/local/bin/docker-entrypoint.sh; \
+    chmod +x /usr/local/bin/docker-entrypoint.sh
+
 VOLUME /data
 WORKDIR /data
+
 ENV KEYDB_PRO_DIRECTORY=/usr/local/bin/
+
 ENTRYPOINT ["docker-entrypoint.sh"]
+
 EXPOSE 6379
-CMD ["keydb-server","/etc/keydb/keydb.conf"]
+
+CMD ["keydb-server", "/etc/keydb/keydb.conf"]


### PR DESCRIPTION
* Merged multiple `RUN` commands where possible to reduce the number of layers.

* Removed unnecessary `grep` commands and simplified the disabling of protected mode.

* Removed redundant `cd` commands by combining them with the subsequent commands.

* Simplified the `find` and `chown` commands in the `entrypoint` script.

* Removed the `echo $savedAptMark` command as it doesn't serve a meaningful purpose.