### PR TITLE
Try and fix the Fedora packaging

### DIFF
--- a/pkg/rpm/keydb_build/keydb.spec
+++ b/pkg/rpm/keydb_build/keydb.spec
@@ -1,4 +1,4 @@
-Name        : keydb
+Name        : KeyDB
 Version     : 6.0.5
 Release     : 1%{?dist}
 Group       : Unspecified


### PR DESCRIPTION
Hi, I'm a Fedora packager and found KeyDB was not in Fedora, so I try to fix that. :wink: 

I had to modify the `spec` file because it wouldn't build as it was: 

---

This was needed to properly build and find the generated SRPM somehow.

The build still fails though:

```
RPM build errors:
error: File not found: /builddir/build/BUILDROOT/KeyDB-6.0.5-1.fc40.x86_64/etc/logrotate.d/keydb
error: File not found: /builddir/build/BUILDROOT/KeyDB-6.0.5-1.fc40.x86_64/etc/systemd/system/keydb.service.d/limit.conf
error: File not found: /builddir/build/BUILDROOT/KeyDB-6.0.5-1.fc40.x86_64/etc/systemd/system/keydb-sentinel.service.d/limit.conf
error: File not found: /builddir/build/BUILDROOT/KeyDB-6.0.5-1.fc40.x86_64/usr/bin/*
error: File not found: /builddir/build/BUILDROOT/KeyDB-6.0.5-1.fc40.x86_64/usr/lib/systemd/system/*
error: File not found: /builddir/build/BUILDROOT/KeyDB-6.0.5-1.fc40.x86_64/usr/libexec/*
error: File not found: /builddir/build/BUILDROOT/KeyDB-6.0.5-1.fc40.x86_64/usr/share/licenses/*
error: File not found: /builddir/build/BUILDROOT/KeyDB-6.0.5-1.fc40.x86_64/usr/share/man/man1/*
error: File not found: /builddir/build/BUILDROOT/KeyDB-6.0.5-1.fc40.x86_64/usr/share/man/man5/*
error: File not found: /builddir/build/BUILDROOT/KeyDB-6.0.5-1.fc40.x86_64/var/lib/*
error: File not found: /builddir/build/BUILDROOT/KeyDB-6.0.5-1.fc40.x86_64/var/log/*
error: File not found: /builddir/build/BUILDROOT/KeyDB-6.0.5-1.fc40.x86_64/usr/lib64/redis/modules
error: File not found: /builddir/build/BUILDROOT/KeyDB-6.0.5-1.fc40.x86_64/etc/keydb/*
    File not found: /builddir/build/BUILDROOT/KeyDB-6.0.5-1.fc40.x86_64/etc/logrotate.d/keydb
    File not found: /builddir/build/BUILDROOT/KeyDB-6.0.5-1.fc40.x86_64/etc/systemd/system/keydb.service.d/limit.conf
    File not found: /builddir/build/BUILDROOT/KeyDB-6.0.5-1.fc40.x86_64/etc/systemd/system/keydb-sentinel.service.d/limit.conf
    File not found: /builddir/build/BUILDROOT/KeyDB-6.0.5-1.fc40.x86_64/usr/bin/*
    File not found: /builddir/build/BUILDROOT/KeyDB-6.0.5-1.fc40.x86_64/usr/lib/systemd/system/*
    File not found: /builddir/build/BUILDROOT/KeyDB-6.0.5-1.fc40.x86_64/usr/libexec/*
    File not found: /builddir/build/BUILDROOT/KeyDB-6.0.5-1.fc40.x86_64/usr/share/licenses/*
    File not found: /builddir/build/BUILDROOT/KeyDB-6.0.5-1.fc40.x86_64/usr/share/man/man1/*
    File not found: /builddir/build/BUILDROOT/KeyDB-6.0.5-1.fc40.x86_64/usr/share/man/man5/*
    File not found: /builddir/build/BUILDROOT/KeyDB-6.0.5-1.fc40.x86_64/var/lib/*
    File not found: /builddir/build/BUILDROOT/KeyDB-6.0.5-1.fc40.x86_64/var/log/*
    File not found: /builddir/build/BUILDROOT/KeyDB-6.0.5-1.fc40.x86_64/usr/lib64/redis/modules
    File not found: /builddir/build/BUILDROOT/KeyDB-6.0.5-1.fc40.x86_64/etc/keydb/*
Finish: rpmbuild KeyDB-6.0.5-1.fc41.src.rpm
Finish: build phase for KeyDB-6.0.5-1.fc41.src.rpm
ERROR: Exception(/home/bochecha/Packages/KeyDB/KeyDB-6.0.5-1.fc41.src.rpm) Config(fedora-40-x86_64) 0 minutes 17 seconds
INFO: Results and/or logs in: /home/bochecha/Packages/KeyDB/results_KeyDB/6.0.5/1.fc41
INFO: Cleaning up build root ('cleanup_on_failure=True')
Start: clean chroot
Finish: clean chroot
ERROR: Command failed:
 # /usr/bin/systemd-nspawn -q -M 01555998ddd141279a5fb39c36f1e06f -D /var/lib/mock/fedora-40-x86_64/root -a -u mockbuild --capability=cap_ipc_lock --bind=/tmp/mock-resolv.nim7e9tm:/etc/resolv.conf --bind=/dev/btrfs-control --bind=/dev/mapper/control --bind=/dev/fuse --bind=/dev/loop-control --bind=/dev/loop0 --bind=/dev/loop1 --bind=/dev/loop2 --bind=/dev/loop3 --bind=/dev/loop4 --bind=/dev/loop5 --bind=/dev/loop6 --bind=/dev/loop7 --bind=/dev/loop8 --bind=/dev/loop9 --bind=/dev/loop10 --bind=/dev/loop11 --console=pipe --setenv=TERM=vt100 --setenv=SHELL=/bin/bash --setenv=HOME=/builddir --setenv=HOSTNAME=mock --setenv=PATH=/usr/bin:/bin:/usr/sbin:/sbin '--setenv=PROMPT_COMMAND=printf "\033]0;<mock-chroot>\007"' '--setenv=PS1=<mock-chroot> \s-\v\$ ' --setenv=LANG=C.UTF-8 --resolv-conf=off bash --login -c '/usr/bin/rpmbuild -bb  --target x86_64 --nodeps /builddir/build/SPECS/keydb.spec'

Could not execute mockbuild: Failed to execute command.
```