### PR TITLE
Fix crash in replicationCacheMaster() expecting a nullptr cached_master

### DIFF
--- a/src/replication.cpp
+++ b/src/replication.cpp
@@ -2343,6 +2343,10 @@ void replicationEmptyDbCallback(void *privdata) {
 void replicationCreateMasterClient(redisMaster *mi, connection *conn, int dbid) {
     serverAssert(mi->master == nullptr);
     mi->master = createClient(conn, serverTL - g_pserver->rgthreadvar);
+    if (mi->cached_master != nullptr) {
+        freeClientAsync(mi->cached_master);
+        mi->cached_master = nullptr;
+    }
     if (conn)
     {
         serverAssert(connGetPrivateData(mi->master->conn) == mi->master);


### PR DESCRIPTION
The replicationCacheMaster() function expects the master pointer to be non-nullptr and the cached_master to be nullptr. But if we happened to get disconnected multiple times and thus also go multiple times through replicationCreateMasterClient(), then we end up with both master and cached_master being non-nullptr, which then triggers an assertion in replicationCacheMaster() which crashes the server.

When we are recreating the master struct, mark cached_master for asynchronous freeing, and reset its pointer.

Fixes: #849

This fixes this crash for us, but then we get after a bit another apparently unrelated crash, although that might be due to the database being damaged (which was the trigger in our case) or something else. But given the amount of crash reports filed, this does not seem surprising.