### PR TITLE
Fix issue of listen before chmod on Unix sockets (CVE-2023-45145)

### DIFF
--- a/src/anet.c
+++ b/src/anet.c
@@ -411,12 +411,15 @@ int anetUnixGenericConnect(char *err, const char *path, int flags)
     return s;
 }
 
-static int anetListen(char *err, int s, struct sockaddr *sa, socklen_t len, int backlog) {
+static int anetListen(char *err, int s, struct sockaddr *sa, socklen_t len, int backlog, mode_t perm) {
     if (bind(s,sa,len) == -1) {
         anetSetError(err, "bind: %s", strerror(errno));
         close(s);
         return ANET_ERR;
     }
+
+    if (sa->sa_family == AF_LOCAL && perm)
+        chmod(((struct sockaddr_un *) sa)->sun_path, perm);
 
     if (listen(s, backlog) == -1) {
         anetSetError(err, "listen: %s", strerror(errno));
@@ -462,7 +465,7 @@ static int _anetTcpServer(char *err, int port, const char *bindaddr, int af, int
         if (af == AF_INET6 && anetV6Only(err,s) == ANET_ERR) goto error;
         if (anetSetReuseAddr(err,s) == ANET_ERR) goto error;
         if (fReusePort && !fFirstListen && anetSetReusePort(err,s) == ANET_ERR) goto error;
-        if (anetListen(err,s,p->ai_addr,p->ai_addrlen,backlog) == ANET_ERR) {
+        if (anetListen(err,s,p->ai_addr,p->ai_addrlen,backlog,0) == ANET_ERR) {
             s = ANET_ERR;
             goto end;
         }
@@ -503,10 +506,8 @@ int anetUnixServer(char *err, char *path, mode_t perm, int backlog)
     memset(&sa,0,sizeof(sa));
     sa.sun_family = AF_LOCAL;
     strncpy(sa.sun_path,path,sizeof(sa.sun_path)-1);
-    if (anetListen(err,s,(struct sockaddr*)&sa,sizeof(sa),backlog) == ANET_ERR)
+    if (anetListen(err,s,(struct sockaddr*)&sa,sizeof(sa),backlog,perm) == ANET_ERR)
         return ANET_ERR;
-    if (perm)
-        chmod(sa.sun_path, perm);
     return s;
 }
 


### PR DESCRIPTION
**Description**
This PR fixes a potential vulnerability in anetListen() in `src/anet.c` that was cloned from redid but did not receive the security patch. The original issue was reported and fixed under https://github.com/redis/redis/commit/03345ddc7faf7af079485f2cbe5d17a1611cbce1.
This PR applies the same patch to eliminate the vulnerability.

References
https://nvd.nist.gov/vuln/detail/CVE-2023-45145
https://github.com/redis/redis/commit/03345ddc7faf7af079485f2cbe5d17a1611cbce1